### PR TITLE
Rend la fonction readValue synchrone

### DIFF
--- a/lib/schema/error-labels.js
+++ b/lib/schema/error-labels.js
@@ -3,7 +3,7 @@
 module.exports = {
   // *
   '*.valeur_manquante': 'Le champ {} ne doit pas être vide',
-  '*.valeur_invalide': 'Le valeur du champ {} est incorrecte',
+  '*.valeur_invalide': 'La valeur du champ {} est incorrecte',
   '*.espaces_debut_fin': 'La valeur du champ {} ne doit pas avoir d’espaces en début ou en fin de chaîne de caractère',
   '*.enum_fuzzy': 'La valeur du champ {} a été acceptée mais n’est pas conforme à la spécification',
   '*.caractere_invalide': 'Le champ {} contient des caractères non valides',

--- a/lib/validate/row.js
+++ b/lib/validate/row.js
@@ -19,7 +19,7 @@ function buildRawValues(row, indexedFields) {
   return rawValues
 }
 
-async function readValue(fieldName, rawValue) {
+function readValue(fieldName, rawValue) {
   if (!(fieldName in schema.fields)) {
     throw new Error(`Unknown field name: ${fieldName}`)
   }
@@ -43,7 +43,7 @@ async function readValue(fieldName, rawValue) {
   } else if (!trimmedValue) {
     // Ne rien faire
   } else if (def.parse) {
-    result.parsedValue = await def.parse(trimmedValue, {
+    result.parsedValue = def.parse(trimmedValue, {
       setAdditionnalValues(values) {
         result.additionalValues = values
       },


### PR DESCRIPTION
## Contexte
La fonction `readValue` est actuellement asynchrone. Or cette spécificité n'est pas utilisée et empêche une intégration simple dans le processus de validation des données avec [joi](https://joi.dev) qui est utilisé dans [mes-adresses-api](https://github.com/BaseAdresseNationale/mes-adresses-api).

### Autre
- Correction d'une faute sur le label d'erreur `*.valeur_invalide`