### PR TITLE
Changement du prefix @etalab en @ban-team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Validateur de fichier "Base Adresse Locale"
 
-[![npm version](https://badgen.net/npm/v/@etalab/bal)](https://www.npmjs.com/package/@etalab/bal)
-[![dependencies Status](https://david-dm.org/etalab/bal/status.svg)](https://david-dm.org/etalab/bal)
-[![codecov](https://badgen.net/codecov/c/github/etalab/bal)](https://codecov.io/gh/etalab/bal)
+[![npm version](https://badgen.net/npm/v/@ban-team/validateur-bal)](https://www.npmjs.com/package/@ban-team/validateur-bal)
+[![codecov](https://badgen.net/codecov/c/github/BaseAdresseNationale/validateur-bal)](https://codecov.io/gh/BaseAdresseNationale/validateur-bal)
 [![XO code style](https://badgen.net/badge/code%20style/XO/cyan)](https://github.com/xojs/xo)
 
 ## Principe
@@ -12,7 +11,7 @@ Une Base Adresse Locale est typiquement une base de données voies-adresses main
 Afin de normaliser la production de fichiers informatiques d'échange pour alimenter la [Base Adresse Nationale](https://adresse.data.gouv.fr/), un groupe de travail du [Groupe SIG et topographie de l'Association des Ingénieurs Territoriaux de France](http://aitf.fr/groupe-travail/sig-topographie) (AITF) a publié une proposition de modèle de données simple.
 Ce document est disponible [ici](assets/AITF-SIG-Topo-Adresse--Fichier-echange-modele-simple-v1.1.pdf).
 
-Le logiciel disponible en téléchargement [sur cette page](https://github.com/BaseAdresseNationale/bal/releases) permet de contrôler et valider un fichier "Base Adresse Locale" (BAL) produit conformément au modèle de données ci-dessus.
+Le logiciel disponible en téléchargement [sur cette page](https://github.com/BaseAdresseNationale/validateur-bal/releases) permet de contrôler et valider un fichier "Base Adresse Locale" (BAL) produit conformément au modèle de données ci-dessus.
 
 
 ## Utilisation

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@etalab/bal",
+  "name": "@ban-team/validateur-bal",
   "version": "2.6.0",
   "description": "Validateur de référence pour le format BAL",
-  "repository": "https://github.com/BaseAdresseNationale/bal",
+  "repository": "https://github.com/BaseAdresseNationale/validateur-bal",
   "author": "Équipe Adresse <adresse@data.gouv.fr>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Contexte
Le projet change d'organisation et passe de `@etalab` à `@ban-team`.
Par la même occasion, le projet change de nom et devient `validateur-bal`.