### PR TITLE
Utilisation de la liste des langues régionales issue de `@ban-team/shared-data`

### DIFF
--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: off */
 const {format, parseISO} = require('date-fns')
 const {trim, trimStart, deburr} = require('lodash')
+const languesRegionales = require('@ban-team/shared-data/langues-regionales.json')
 const proj = require('@etalab/project-legal')
 const {isCommune, isCommuneActuelle, isCommuneDeleguee, isCommuneAncienne, getCommuneActuelle} = require('../cog')
 
@@ -16,7 +17,7 @@ function includesInvalidChar(str) {
   return str.includes('�')
 }
 
-exports.allowedLocales = ['fra', 'bre', 'eus', 'gsw', 'cos', 'gyn', 'rcf', 'oci']
+exports.allowedLocales = languesRegionales.map(l => l.code)
 
 exports.fields = {
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepublishOnly": "yarn build-minicog && yarn transpile"
   },
   "dependencies": {
+    "@ban-team/shared-data": "^1.0.0",
     "@etalab/project-legal": "^0.6.0",
     "blob-to-buffer": "^1.2.9",
     "bluebird": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@ban-team/shared-data@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
+  integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"


### PR DESCRIPTION
Pour éviter d'avoir à gérer des listes de langues à plusieurs endroits (qui avaient déjà commencé à diverger), la liste officielle a été intégrée à un dépôt dédié aux données partagées.