### PR TITLE
Mise à jour de @ban-team/shared-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "yarn build-minicog && yarn transpile"
   },
   "dependencies": {
-    "@ban-team/shared-data": "^1.0.1",
+    "@ban-team/shared-data": "^1.1.0",
     "@etalab/project-legal": "^0.6.0",
     "blob-to-buffer": "^1.2.9",
     "bluebird": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@ban-team/shared-data@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.1.tgz#bc3f49beab5bf492ad5da4d2a3852a539e68416b"
-  integrity sha512-eRrAZ2QJRiYd3wiPQE1ejA8fwn18AWvKASaEn7ajGVxIjOD5ty3E2hKlLPDOjdrg/bsVrabzOvxnnUN0sxboIA==
+"@ban-team/shared-data@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
+  integrity sha512-+SnPGySf715hd2pvygtCN24uGZNBMAeY8mNvt1WC7a+sPtjz74HL7+S+ff7SiZIrSYioSJi+OZp5t8QHgk2X/A==
 
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"


### PR DESCRIPTION
## Contexte
Mise à jour de `@ban-team/shared-data` en `v.1.1.0`. Cette mise à jour apport le support du Catalan aux langues régionales.