### PR TITLE
Enlève l’avertissement sur les voies vides en langue régionale

### DIFF
--- a/lib/schema/profiles/1.3-etalab.js
+++ b/lib/schema/profiles/1.3-etalab.js
@@ -36,7 +36,6 @@ const warnings = [
   'voie_nom.contient_tiret_bas',
   'voie_nom_@@.casse_incorrecte',
   'voie_nom_@@.contient_tiret_bas',
-  'voie_nom_@@.valeur_manquante',
   'voie_nom_@@.trop_court',
   'voie_nom_@@.trop_long',
   'voie_nom_@@.caractere_invalide',


### PR DESCRIPTION
Cette pull-request enlève l’avertissement concernant les voies en langue régionale lorsqu’elles sont vides.


Fix #66 