### PR TITLE
Mise à jour COG 2023

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.19.1",
     "@babel/preset-env": "^7.19.1",
-    "@etalab/decoupage-administratif": "^2.0.0",
+    "@etalab/decoupage-administratif": "^3.0.0",
     "ava": "^4.3.3",
     "codecov": "^3.8.3",
     "fs-extra": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,10 +1181,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@etalab/decoupage-administratif@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
-  integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
+"@etalab/decoupage-administratif@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz#1d0d54b5b884c3df9555b4b8db543f83559629d3"
+  integrity sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==
 
 "@etalab/project-legal@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
## Contexte
Mise à jour de `@etalab/decoupage-administratif en v3.0.0` pour la mise à jour du COG 2023.