### PR TITLE
Validator bal v2.18.0

### DIFF
--- a/lib/schema/error-labels.js
+++ b/lib/schema/error-labels.js
@@ -80,8 +80,9 @@ module.exports = {
   'row.longlat_invalides': 'Les coordonnées long/lat sont en dehors du territoire ou invalides',
   'row.longlat_xy_incoherents': 'Les coordonnées long/lat et x/y ne sont pas cohérentes',
   'row.adresse_incomplete': 'L’adresse est incomplète (numéro ou nom de la voie non renseignés)',
-  'row.incoherence_ids_ban': 'Les ids ban renseignés ne sont pas cohérents avec les données de la base adresse nationale',
-
+  'row.incoherence_ids_ban': 'Les ids ban renseignés ne sont pas cohérents',
+  'row.id_ban_adresses_required': 'id_ban_adresses est requis les ids ban et le numero sont renseigné',
   // rows
-  'rows.empty': 'Aucune ligne détecté'
+  'rows.empty': 'Aucune ligne détecté',
+  'rows.ids_required_every': 'Les ids ban sont requis pour toutes les lignes si ils sont utlisés'
 }

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -457,6 +457,47 @@ function validateCoords(row, {addError}) {
   }
 }
 
+function checkBanIds(row, addError) {
+  // SI IL Y A UN id_ban_toponyme, IL Y A UN id_ban_commune
+  // SI IL Y A UN id_ban_adresse, IL Y A UN id_ban_toponyme ET DONC IL Y A IL Y A UN id_ban_commune
+  if (
+    (!row.parsedValues.id_ban_commune && row.parsedValues.id_ban_toponyme)
+    || ((!row.parsedValues.id_ban_commune || !row.parsedValues.id_ban_toponyme) && row.parsedValues.id_ban_adresse)
+  ) {
+    addError('incoherence_ids_ban')
+  }
+
+  // LES IDS id_ban_commune / id_ban_toponyme / id_ban_adresse NE PEUVENT PAS ËTRE IDENTIQUES
+  if (
+    (
+      row.parsedValues.id_ban_commune
+        && row.parsedValues.id_ban_toponyme
+        && row.parsedValues.id_ban_commune === row.parsedValues.id_ban_toponyme
+    ) || (
+      row.parsedValues.id_ban_commune
+       && row.parsedValues.id_ban_adresse
+        && row.parsedValues.id_ban_commune === row.parsedValues.id_ban_adresse
+    ) || (
+      row.parsedValues.id_ban_adresse
+        && row.parsedValues.id_ban_toponyme
+        && row.parsedValues.id_ban_toponyme === row.parsedValues.id_ban_adresse
+    )
+  ) {
+    addError('incoherence_ids_ban')
+  }
+
+  // SI IL Y A UN id_ban_toponyme, id_ban_commune ET UN numero, IL FAUT UN id_ban_adresse
+  if (
+    row.parsedValues.id_ban_commune
+    && row.parsedValues.id_ban_toponyme
+    && row.parsedValues.numero
+    && row.parsedValues.numero !== 99_999
+    && !row.parsedValues.id_ban_adresse
+  ) {
+    addError('id_ban_adresses_required')
+  }
+}
+
 exports.row = (row, {addError}) => {
   if (row.parsedValues.cle_interop && row.parsedValues.numero) {
     const {numeroVoie} = row.additionalValues.cle_interop
@@ -489,21 +530,5 @@ exports.row = (row, {addError}) => {
     }
   }
 
-  if (
-    (
-      row.parsedValues.id_ban_commune
-        && row.parsedValues.id_ban_toponyme
-        && row.parsedValues.id_ban_commune === row.parsedValues.id_ban_toponyme
-    ) || (
-      row.parsedValues.id_ban_commune
-       && row.parsedValues.id_ban_adresse
-      && row.parsedValues.id_ban_commune === row.parsedValues.id_ban_adresse
-    ) || (
-      row.parsedValues.id_ban_adresse
-      && row.parsedValues.id_ban_toponyme
-      && row.parsedValues.id_ban_toponyme === row.parsedValues.id_ban_adresse
-    )
-  ) {
-    addError('incoherence_ids_ban')
-  }
+  checkBanIds(row, addError)
 }

--- a/lib/schema/profiles/1.3.js
+++ b/lib/schema/profiles/1.3.js
@@ -33,23 +33,12 @@ const errors = [
   'row.longlat_vides',
   'row.longlat_invalides',
   'row.adresse_incomplete',
-
-  //  'field.cle_interop.missing',
   'field.commune_insee.missing',
-  // 'field.commune_nom.missing',
   'field.voie_nom.missing',
   'field.numero.missing',
-  // 'field.commune_nom.position',
-  // 'field.commune_nom.x',
-  // 'field.commune_nom.y',
   'field.commune_nom.long',
   'field.commune_nom.lat',
-  // 'field.commune_nom.source',
-  // 'field.commune_nom.date_der_maj',
-  // 'field.commune_nom.certification_commune',
-
   'suffixe.espaces_debut_fin',
-
   'file.encoding.non_standard',
   'file.delimiter.non_standard',
   'file.linebreak.non_standard',
@@ -119,7 +108,7 @@ const infos = [
 
 module.exports = {
   code: '1.3',
-  name: 'BAL 1.3',
+  name: 'BAL 1.3 (défaut)',
   isUsed: false,
   relax: false,
   errors,

--- a/lib/schema/profiles/1.4-relax.js
+++ b/lib/schema/profiles/1.4-relax.js
@@ -93,11 +93,16 @@ const warnings = [
   'cad_parcelles.espaces_debut_fin',
   'source.espaces_debut_fin',
   'date_der_maj.espaces_debut_fin',
-
+  // ID BAN
+  'field.id_ban_commune.missing',
+  'field.id_ban_toponyme.missing',
+  'field.id_ban_adresse.missing',
   'id_ban_commune.type_invalide',
   'id_ban_toponyme.type_invalide',
   'id_ban_adresse.type_invalide',
-  'row.incoherence_ids_ban'
+  'row.incoherence_ids_ban',
+  'row.id_ban_adresses_required',
+  'rows.ids_required_every'
 ]
 
 const infos = [
@@ -106,7 +111,7 @@ const infos = [
 
 module.exports = {
   code: '1.4-relax',
-  name: 'BAL 1.4 Relax',
+  name: 'BAL 1.4 Relax (beta)',
   isUsed: true,
   relax: true,
   errors,

--- a/lib/schema/profiles/1.4.js
+++ b/lib/schema/profiles/1.4.js
@@ -33,19 +33,23 @@ const errors = [
   'row.longlat_vides',
   'row.longlat_invalides',
   'row.adresse_incomplete',
-
   'field.commune_insee.missing',
   'field.voie_nom.missing',
   'field.numero.missing',
   'field.commune_nom.long',
   'field.commune_nom.lat',
-
   'suffixe.espaces_debut_fin',
-
   'file.encoding.non_standard',
   'file.delimiter.non_standard',
   'file.linebreak.non_standard',
-  'rows.empty'
+  'rows.empty',
+
+  'id_ban_commune.type_invalide',
+  'id_ban_toponyme.type_invalide',
+  'id_ban_adresse.type_invalide',
+  'row.incoherence_ids_ban',
+  'row.id_ban_adresses_required',
+  'rows.ids_required_every'
 ]
 
 const warnings = [
@@ -103,14 +107,10 @@ const warnings = [
   'cad_parcelles.espaces_debut_fin',
   'source.espaces_debut_fin',
   'date_der_maj.espaces_debut_fin',
+  // ID BAN
   'field.id_ban_commune.missing',
   'field.id_ban_toponyme.missing',
-  'field.id_ban_adresse.missing',
-
-  'id_ban_commune.type_invalide',
-  'id_ban_toponyme.type_invalide',
-  'id_ban_adresse.type_invalide',
-  'row.incoherence_ids_ban'
+  'field.id_ban_adresse.missing'
 ]
 
 const infos = [
@@ -119,7 +119,7 @@ const infos = [
 
 module.exports = {
   code: '1.4',
-  name: 'BAL 1.4',
+  name: 'BAL 1.4 (beta)',
   isUsed: true,
   relax: false,
   errors,

--- a/lib/validate/__tests__/1.4/data/1.4-bad-dependance-id-ban.csv
+++ b/lib/validate/__tests__/1.4/data/1.4-bad-dependance-id-ban.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;;8a3bab10-f329-4ce3-9c7d-280d91a8053a;3c87abe4-887b-46ee-9192-5c1b35a06625;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/lib/validate/__tests__/1.4/data/1.4-good-dependance-id-ban.csv
+++ b/lib/validate/__tests__/1.4/data/1.4-good-dependance-id-ban.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842e;;;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/lib/validate/__tests__/1.4/data/1.4-no-ids-ban-every.csv
+++ b/lib/validate/__tests__/1.4/data/1.4-no-ids-ban-every.csv
@@ -1,3 +1,3 @@
 cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
 31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842e;8a3bab10-f329-4ce3-9c7d-280d91a8053a;3c87abe4-887b-46ee-9192-5c1b35a06625;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09
-31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842e;8a3bab10-f329-4ce3-9c7d-280d91a8053a;3c87abe4-887b-46ee-9192-5c1b35a06625;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09
+31591_xxxx_00009;;;;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/lib/validate/__tests__/1.4/data/1.4-without-ban-adresse.csv
+++ b/lib/validate/__tests__/1.4/data/1.4-without-ban-adresse.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842e;0246e48c-f33d-433a-8984-034219be842e;;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/lib/validate/__tests__/1.4/index.js
+++ b/lib/validate/__tests__/1.4/index.js
@@ -15,7 +15,6 @@ function readAsBuffer(relativePath) {
 test('Valid file 1.3', async t => {
   const buffer = await readAsBuffer('1.3-valid.csv')
   const report = await validate(buffer, {profile: '1.3'})
-
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
   t.is(report.profilesValidation[1.4].isValid, true)
@@ -24,7 +23,7 @@ test('Valid file 1.3', async t => {
 
 test('Valid file 1.4', async t => {
   const buffer = await readAsBuffer('1.4-valid.csv')
-  const report = await validate(buffer)
+  const report = await validate(buffer, {profile: '1.4'})
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
   t.is(report.profilesValidation[1.4].isValid, true)
@@ -71,57 +70,136 @@ test('Error file 1.4 with profile 1.4', async t => {
 
 test('Error bad id ban adresses (file 1.4)', async t => {
   const buffer = await readAsBuffer('1.4-bad-id-ban-adresse.csv')
-  const report = await validate(buffer)
+  const report = await validate(buffer, {profile: '1.4'})
 
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
-  t.is(report.profilesValidation[1.4].isValid, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
   t.is(report.profilesValidation['1.4-relax'].isValid, true)
 
   const error = report.profilErrors.filter(e => e.code === 'id_ban_adresse.type_invalide')
   t.is(error.length, 1)
-  t.is(error[0].level, 'W')
+  t.is(error[0].level, 'E')
 })
 
 test('Error bad id ban commune (file 1.4)', async t => {
   const buffer = await readAsBuffer('1.4-bad-id-ban-commune.csv')
-  const report = await validate(buffer)
+  const report = await validate(buffer, {profile: '1.4'})
 
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
-  t.is(report.profilesValidation[1.4].isValid, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
   t.is(report.profilesValidation['1.4-relax'].isValid, true)
 
   const error = report.profilErrors.filter(e => e.code === 'id_ban_commune.type_invalide')
   t.is(error.length, 1)
-  t.is(error[0].level, 'W')
+  t.is(error[0].level, 'E')
 })
 
 test('Error bad id ban toponyme a (file 1.4)', async t => {
   const buffer = await readAsBuffer('1.4-bad-id-ban-toponyme.csv')
-  const report = await validate(buffer)
+  const report = await validate(buffer, {profile: '1.4'})
 
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
-  t.is(report.profilesValidation[1.4].isValid, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
   t.is(report.profilesValidation['1.4-relax'].isValid, true)
 
   const error = report.profilErrors.filter(e => e.code === 'id_ban_toponyme.type_invalide')
   t.is(error.length, 1)
-  t.is(error[0].level, 'W')
+  t.is(error[0].level, 'E')
 })
 
 test('Error incoherent ban id (file 1.4)', async t => {
   const buffer = await readAsBuffer('1.4-incoherent-id-ban.csv')
-  const report = await validate(buffer)
+  const report = await validate(buffer, {profile: '1.4'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
+
+  const error = report.profilErrors.filter(e => e.code === 'row.incoherence_ids_ban')
+  t.is(error.length, 1)
+  t.is(error[0].level, 'E')
+})
+
+test('Good incoherent dependance ban id (file 1.4)', async t => {
+  const buffer = await readAsBuffer('1.4-good-dependance-id-ban.csv')
+  const report = await validate(buffer, {profile: '1.4'})
 
   t.is(report.encoding, 'utf-8')
   t.is(report.parseOk, true)
   t.is(report.profilesValidation[1.4].isValid, true)
   t.is(report.profilesValidation['1.4-relax'].isValid, true)
+})
+
+test('Error incoherent dependance ban id (file 1.4)', async t => {
+  const buffer = await readAsBuffer('1.4-bad-dependance-id-ban.csv')
+  const report = await validate(buffer, {profile: '1.4'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
 
   const error = report.profilErrors.filter(e => e.code === 'row.incoherence_ids_ban')
+  t.is(error.length, 1)
+  t.is(error[0].level, 'E')
+})
+
+test('Warning id_ban_adresses_required (file 1.4) with profile relax', async t => {
+  const buffer = await readAsBuffer('1.4-without-ban-adresse.csv')
+  const report = await validate(buffer, {profile: '1.4-relax'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
+
+  const error = report.profilErrors.filter(e => e.code === 'row.id_ban_adresses_required')
   t.is(error.length, 1)
   t.is(error[0].level, 'W')
 })
 
+test('ERROR id_ban_adresses_required (file 1.4)', async t => {
+  const buffer = await readAsBuffer('1.4-without-ban-adresse.csv')
+  const report = await validate(buffer, {profile: '1.4'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
+
+  const error = report.profilErrors.filter(e => e.code === 'row.id_ban_adresses_required')
+  t.is(error.length, 1)
+  t.is(error[0].level, 'E')
+})
+
+test('Warning rows.ids_required_every (file 1.4) with profile relax', async t => {
+  const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv')
+  const report = await validate(buffer, {profile: '1.4-relax'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
+
+  const error = report.profilErrors.filter(e => e.code === 'rows.ids_required_every')
+  t.is(error.length, 1)
+  t.is(error[0].level, 'W')
+})
+
+test('Warning rows.ids_required_every (file 1.4)', async t => {
+  const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv')
+  const report = await validate(buffer, {profile: '1.4'})
+
+  t.is(report.encoding, 'utf-8')
+  t.is(report.parseOk, true)
+  t.is(report.profilesValidation[1.4].isValid, false)
+  t.is(report.profilesValidation['1.4-relax'].isValid, true)
+
+  const error = report.profilErrors.filter(e => e.code === 'rows.ids_required_every')
+  t.is(error.length, 1)
+  t.is(error[0].level, 'E')
+})

--- a/lib/validate/index.js
+++ b/lib/validate/index.js
@@ -82,10 +82,26 @@ function validateFile(detectedParams, {globalErrors}) {
   return {encoding, delimiter, linebreak}
 }
 
+function checkUseBanIdsEveryRow(parsedRows, {globalErrors}) {
+  if (parsedRows.length > 0) {
+    const useBanIds = 'id_ban_commune' in parsedRows[0]
+    for (const row of parsedRows) {
+      if (
+        (useBanIds && row.id_ban_commune === '')
+        || (!useBanIds && (row.id_ban_commune !== undefined && row.id_ban_commune !== ''))) {
+        globalErrors.add('rows.ids_required_every')
+        return
+      }
+    }
+  }
+}
+
 function validateRows(parsedRows, {globalErrors}) {
   if (parsedRows.length <= 0) {
     globalErrors.add('rows.empty')
   }
+
+  checkUseBanIdsEveryRow(parsedRows, {globalErrors})
 }
 
 async function prevalidate(file, relaxFieldsDetection) {
@@ -177,7 +193,7 @@ function validateProfile(prevalidateResult, profileName) {
 }
 
 async function validate(file, options = {}) {
-  const profile = options.profile || '1.4'
+  const profile = options.profile || '1.3'
   let {relaxFieldsDetection} = options
 
   if (options.relaxFieldsDetection === undefined) {


### PR DESCRIPTION
## Ajout

- Ajout de l'error/warning `row.id_ban_adresses_required` lorsque une ligne avec numero, id_ban_commune, id_ban_toponyme et pas id_ban_numero

- Ajout de l'error/warning `rows.ids_required_every` les ids ban doivent être sur toutes les lignes ou aucune

## Changement 

### Profile 1.4
#### ERROR
  - 'id_ban_commune.type_invalide',
  - 'id_ban_toponyme.type_invalide',
  - 'id_ban_adresse.type_invalide',
  - 'row.incoherence_ids_ban',
  - 'row.id_ban_adresses_required',
  - 'rows.ids_required_every'
#### WARNING
  - 'field.id_ban_commune.missing',
  - 'field.id_ban_toponyme.missing',
  - 'field.id_ban_adresse.missing'

### Profile 1.4 relax

#### WARNING
  - 'field.id_ban_commune.missing',
  - 'field.id_ban_toponyme.missing',
  - 'field.id_ban_adresse.missing',
  - 'id_ban_commune.type_invalide',
  - 'id_ban_toponyme.type_invalide',
  - 'id_ban_adresse.type_invalide',
  - 'row.incoherence_ids_ban',
  - 'row.id_ban_adresses_required',
  - 'rows.ids_required_every'
