### PR TITLE
feat: remediation ban ids

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+BAN_API_URL=https://plateforme.adresse.data.gouv.fr

--- a/bin/bal
+++ b/bin/bal
@@ -1,19 +1,16 @@
 #!/usr/bin/env node
 /* eslint no-unused-expressions: off */
 
-const yargs = require("yargs");
+const yargs = require('yargs');
 
 yargs
-  .usage("Utilisation: $0 <command>")
-  .commandDir("../dist/commands")
-  .example(
-    "$0 validate xxxxxx_bal_xxxxxxxxx.csv",
-    "Validation d’un fichier BAL"
-  )
+  .usage('Utilisation: $0 <command>')
+  .commandDir('../dist/commands')
+  .example('$0 validate file.csv', 'Valider un fichier BAL')
   .help()
-  .demandCommand(1, "Vous devez utiliser une des commandes disponibles.").argv;
+  .demandCommand(1, 'Vous devez utiliser une des commandes disponibles.').argv;
 
-process.on("unhandledRejection", (reason, p) => {
-  console.log("Unhandled Rejection at:", p, "reason:", reason);
+process.on('unhandledRejection', (reason, p) => {
+  console.log('Unhandled Rejection at:', p, 'reason:', reason);
   process.exit(1);
 });

--- a/lib/commands/autofix.ts
+++ b/lib/commands/autofix.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'fs-extra';
+import fs from 'fs';
+
+import { autofix } from '../index';
+
+module.exports = {
+  command: 'autofix <file> <fixed_file>',
+  describe: "Mise en forme d'un fichier BAL",
+  async handler(argv) {
+    const file = await readFile(argv.file);
+    try {
+      const buffer: Buffer = await autofix(file);
+      fs.writeFile(argv.fixed_file, buffer, (err) => {
+        if (err) {
+          console.error("Erreur lors de l'écriture du fichier :", err);
+        } else {
+          console.log('Mise en forme du fichier BAL réussi !');
+        }
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  },
+};

--- a/lib/commands/validate.ts
+++ b/lib/commands/validate.ts
@@ -4,7 +4,7 @@ import { validate, getLabel, ValidateType } from '../index';
 
 module.exports = {
   command: 'validate [options] <file>',
-  describe: 'Valider une base Adresse locale',
+  describe: 'Valider un fichier BAL',
   builder: {
     'relax-fields-detection': {
       type: 'boolean',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { validate, prevalidate } from './validate';
+import { validate, prevalidate, autofix } from './validate';
 import { validateProfile } from './validate/profiles';
 import { readValue } from './validate/rows';
 import { getErrorLevel, getLabel, ErrorLevelEnum } from './utils/helpers';
@@ -8,6 +8,7 @@ import { PositionTypeEnum } from './schema/shema.type';
 export {
   validate,
   validateProfile,
+  autofix,
   prevalidate,
   getLabel,
   readValue,

--- a/lib/schema/__tests__/rows.spec.ts
+++ b/lib/schema/__tests__/rows.spec.ts
@@ -18,18 +18,30 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [],
+      },
+    );
     expect(errors).toEqual([]);
   });
 
   it('TEST rows.empty', () => {
     const errors: string[] = [];
     const rows: any[] = [];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [],
+      },
+    );
     expect(errors).toContain('rows.empty');
   });
 
@@ -55,9 +67,15 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [],
+      },
+    );
     expect(errors).toEqual([]);
   });
 
@@ -83,9 +101,15 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
+      },
+    );
     expect(errors).toEqual([]);
   });
 
@@ -111,9 +135,18 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [
+          '8a3bab10-f329-4ce3-9c7d-280d91a8053a',
+          '0246e48c-f33d-433a-8984-034219be842e',
+        ],
+      },
+    );
     expect(errors).toContain('rows.multi_id_ban_commune');
   });
 
@@ -136,9 +169,15 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [],
+      },
+    );
     expect(errors).toContain('rows.every_line_required_id_ban');
   });
 
@@ -165,9 +204,15 @@ describe('VALIDATE ROWS', () => {
         },
       },
     ];
-    validateRows(rows, {
-      addError: (e: string) => errors.push(e),
-    });
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
+      },
+    );
     expect(errors).toContain('rows.every_line_required_id_ban');
   });
 });

--- a/lib/schema/__tests__/rows.spec.ts
+++ b/lib/schema/__tests__/rows.spec.ts
@@ -215,4 +215,91 @@ describe('VALIDATE ROWS', () => {
     );
     expect(errors).toContain('rows.every_line_required_id_ban');
   });
+
+  it('TEST rows.cog_no_match_id_ban_commune', () => {
+    const errors: string[] = [];
+    const rows: any[] = [
+      {
+        additionalValues: {
+          uid_adresse: {
+            idBanCommune: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+        },
+      },
+      {
+        additionalValues: {
+          uid_adresse: {
+            idBanCommune: '0246e48c-f33d-433a-8984-034219be842a',
+            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 2,
+        },
+      },
+    ];
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
+      },
+    );
+    expect(errors).toContain('rows.cog_no_match_id_ban_commune');
+  });
+
+  it('TEST no error rows.cog_no_match_id_ban_commune', () => {
+    const errors: string[] = [];
+    const rows: any[] = [
+      {
+        additionalValues: {
+          uid_adresse: {
+            idBanCommune: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+        },
+      },
+      {
+        additionalValues: {
+          uid_adresse: {
+            idBanCommune: '0246e48c-f33d-433a-8984-034219be842a',
+            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
+            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 2,
+        },
+      },
+    ];
+    validateRows(
+      rows,
+      {
+        addError: (e: string) => errors.push(e),
+      },
+      {
+        communeBanIds: [
+          '0246e48c-f33d-433a-8984-034219be842e',
+          '0246e48c-f33d-433a-8984-034219be842a',
+        ],
+      },
+    );
+    expect(errors).not.toContain('rows.cog_no_match_id_ban_commune');
+  });
 });

--- a/lib/schema/__tests__/rows.spec.ts
+++ b/lib/schema/__tests__/rows.spec.ts
@@ -1,7 +1,19 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
 import validateRows from '../rows';
 
+enableFetchMocks();
+
 describe('VALIDATE ROWS', () => {
-  it('TEST no errors', () => {
+  beforeEach(() => {
+    fetchMock.doMock(async () => {
+      return JSON.stringify({
+        status: 'success',
+        response: [{ id: '0246e48c-f33d-433a-8984-034219be842e' }],
+      });
+    });
+  });
+
+  it('TEST no errors', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -9,43 +21,35 @@ describe('VALIDATE ROWS', () => {
           voie_nom: 'rue du Colombier',
           numero: 1,
           lieudit_complement_nom: 'paradis',
+          commune_insee: '91534',
         },
+        remediations: {},
       },
       {
         parsedValues: {
           voie_nom: 'paradis',
           numero: 99999,
+          commune_insee: '91534',
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toEqual([]);
   });
 
-  it('TEST rows.empty', () => {
+  it('TEST rows.empty', async () => {
     const errors: string[] = [];
     const rows: any[] = [];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toContain('rows.empty');
   });
 
-  it('TEST no ban_ids', () => {
+  it('TEST no ban_ids', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -54,8 +58,10 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '',
           id_ban_adresse: '',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 1,
         },
+        remediations: {},
       },
       {
         parsedValues: {
@@ -63,23 +69,19 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '',
           id_ban_adresse: '',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 2,
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toEqual([]);
   });
 
-  it('TEST no error ban_ids', () => {
+  it('TEST no error ban_ids', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -88,8 +90,10 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '0246e48c-f33d-433a-8984-034219be842e',
           id_ban_adresse: '0246e48c-f33d-433a-8984-034219be842e',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 1,
         },
+        remediations: {},
       },
       {
         parsedValues: {
@@ -97,23 +101,19 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '0246e48c-f33d-433a-8984-034219be842e',
           id_ban_adresse: '',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 99999,
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toEqual([]);
   });
 
-  it('TEST rows.multi_id_ban_commune', () => {
+  it('TEST rows.multi_id_ban_commune', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -122,8 +122,10 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '0246e48c-f33d-433a-8984-034219be842e',
           id_ban_adresse: '0246e48c-f33d-433a-8984-034219be842e',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 1,
         },
+        remediations: {},
       },
       {
         parsedValues: {
@@ -131,26 +133,19 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '8a3bab10-f329-4ce3-9c7d-280d91a8053a',
           id_ban_adresse: '',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 99999,
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [
-          '8a3bab10-f329-4ce3-9c7d-280d91a8053a',
-          '0246e48c-f33d-433a-8984-034219be842e',
-        ],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toContain('rows.multi_id_ban_commune');
   });
 
-  it('TEST rows.every_line_required_id_ban', () => {
+  it('TEST rows.every_line_required_id_ban', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -159,29 +154,27 @@ describe('VALIDATE ROWS', () => {
           id_ban_toponyme: '0246e48c-f33d-433a-8984-034219be842e',
           id_ban_adresse: '0246e48c-f33d-433a-8984-034219be842e',
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 1,
         },
+        remediations: {},
       },
       {
         parsedValues: {
           voie_nom: 'rue du Colombier',
+          commune_insee: '91534',
           numero: 2,
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toContain('rows.every_line_required_id_ban');
   });
 
-  it('TEST uuid_adresse rows.every_line_required_id_ban', () => {
+  it('TEST uuid_adresse rows.every_line_required_id_ban', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -195,28 +188,26 @@ describe('VALIDATE ROWS', () => {
         parsedValues: {
           voie_nom: 'rue du Colombier',
           numero: 1,
+          commune_insee: '91534',
         },
+        remediations: {},
       },
       {
         parsedValues: {
           voie_nom: 'rue du Colombier',
           numero: 2,
+          commune_insee: '91534',
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toContain('rows.every_line_required_id_ban');
   });
 
-  it('TEST rows.cog_no_match_id_ban_commune', () => {
+  it('TEST rows.cog_no_match_id_ban_commune', async () => {
     const errors: string[] = [];
     const rows: any[] = [
       {
@@ -230,7 +221,9 @@ describe('VALIDATE ROWS', () => {
         parsedValues: {
           voie_nom: 'rue du Colombier',
           numero: 1,
+          commune_insee: '91534',
         },
+        remediations: {},
       },
       {
         additionalValues: {
@@ -243,63 +236,14 @@ describe('VALIDATE ROWS', () => {
         parsedValues: {
           voie_nom: 'rue du Colombier',
           numero: 2,
+          commune_insee: '91534',
         },
+        remediations: {},
       },
     ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: ['0246e48c-f33d-433a-8984-034219be842e'],
-      },
-    );
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
     expect(errors).toContain('rows.cog_no_match_id_ban_commune');
-  });
-
-  it('TEST no error rows.cog_no_match_id_ban_commune', () => {
-    const errors: string[] = [];
-    const rows: any[] = [
-      {
-        additionalValues: {
-          uid_adresse: {
-            idBanCommune: '0246e48c-f33d-433a-8984-034219be842e',
-            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
-            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
-          },
-        },
-        parsedValues: {
-          voie_nom: 'rue du Colombier',
-          numero: 1,
-        },
-      },
-      {
-        additionalValues: {
-          uid_adresse: {
-            idBanCommune: '0246e48c-f33d-433a-8984-034219be842a',
-            idBanToponyme: '0246e48c-f33d-433a-8984-034219be842e',
-            idBanAdresse: '0246e48c-f33d-433a-8984-034219be842e',
-          },
-        },
-        parsedValues: {
-          voie_nom: 'rue du Colombier',
-          numero: 2,
-        },
-      },
-    ];
-    validateRows(
-      rows,
-      {
-        addError: (e: string) => errors.push(e),
-      },
-      {
-        communeBanIds: [
-          '0246e48c-f33d-433a-8984-034219be842e',
-          '0246e48c-f33d-433a-8984-034219be842a',
-        ],
-      },
-    );
-    expect(errors).not.toContain('rows.cog_no_match_id_ban_commune');
   });
 });

--- a/lib/schema/error-labels.ts
+++ b/lib/schema/error-labels.ts
@@ -120,11 +120,12 @@ const errorLabels: Record<string, string> = {
   'row.lack_of_id_ban': 'Il y manque un ou plusieurs id ban',
   // ROWS LEVEL ERROR
   'rows.empty': 'Aucune ligne détecté',
-  'rows.multi_id_ban_commune': 'Il ne pas y avoir differents id_ban_commune',
+  'rows.multi_id_ban_commune':
+    'Il ne peut pas y avoir differents id_ban_commune',
   'rows.cog_no_match_id_ban_commune':
     'Le code_insee ne correspond pas au bon id_ban_commune',
   'rows.every_line_required_id_ban':
-    'Les ids ban sont requis pour toutes les lignes si ils sont utlisés',
+    'Les ids ban sont requis pour toutes les lignes si ils sont utilisés',
 };
 
 export default errorLabels;

--- a/lib/schema/error-labels.ts
+++ b/lib/schema/error-labels.ts
@@ -121,6 +121,8 @@ const errorLabels: Record<string, string> = {
   // ROWS LEVEL ERROR
   'rows.empty': 'Aucune ligne détecté',
   'rows.multi_id_ban_commune': 'Il ne pas y avoir differents id_ban_commune',
+  'rows.cog_no_match_id_ban_commune':
+    'Le code_insee ne correspond pas au bon id_ban_commune',
   'rows.every_line_required_id_ban':
     'Les ids ban sont requis pour toutes les lignes si ils sont utlisés',
 };

--- a/lib/schema/profiles/1.4.ts
+++ b/lib/schema/profiles/1.4.ts
@@ -10,6 +10,7 @@ const errors: string[] = [
   'uid_adresse.type_invalide',
   'row.lack_of_id_ban',
   'rows.multi_id_ban_commune',
+  'rows.cog_no_match_id_ban_commune',
   'rows.every_line_required_id_ban',
 ];
 

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -7,7 +7,7 @@ import { ParsedValue } from './shema.type';
 function getCodeCommune(row: ValidateRowType) {
   return (
     row.parsedValues.commune_insee ||
-    row.additionalValues.cle_interop.codeCommune
+    row.additionalValues?.cle_interop?.codeCommune
   );
 }
 
@@ -130,9 +130,9 @@ function validateBanIds(
     addRemeditation: (field: string, value: ParsedValue) => void;
   },
   {
-    indexCommuneBanIds,
+    mapCodeCommuneBanIds,
   }: {
-    indexCommuneBanIds: Record<string, string>;
+    mapCodeCommuneBanIds: Record<string, string>;
   },
 ) {
   const idBanCommune =
@@ -150,7 +150,7 @@ function validateBanIds(
     let isLackOfIdBan = false;
     if (!idBanCommune) {
       const codeCommune = getCodeCommune(row);
-      addRemeditation('id_ban_commune', indexCommuneBanIds[codeCommune]);
+      addRemeditation('id_ban_commune', mapCodeCommuneBanIds[codeCommune]);
       isLackOfIdBan = true;
     }
     if (!idBanToponyme) {
@@ -164,6 +164,11 @@ function validateBanIds(
     if (isLackOfIdBan) {
       addError('lack_of_id_ban');
     }
+  } else {
+    const codeCommune = getCodeCommune(row);
+    addRemeditation('id_ban_commune', mapCodeCommuneBanIds[codeCommune]);
+    addRemeditation('id_ban_toponyme', uuid());
+    addRemeditation('id_ban_adresse', uuid());
   }
 }
 
@@ -177,9 +182,9 @@ function validateRow(
     addRemeditation: (field: string, value: ParsedValue) => void;
   },
   {
-    indexCommuneBanIds,
+    mapCodeCommuneBanIds,
   }: {
-    indexCommuneBanIds: Record<string, string>;
+    mapCodeCommuneBanIds: Record<string, string>;
   },
 ) {
   validateCleInterop(row, { addError });
@@ -187,7 +192,7 @@ function validateRow(
   validateCoords(row, { addError });
   validateMinimalAdress(row, { addError });
   validateCommuneDelegueeInsee(row, { addError });
-  validateBanIds(row, { addError, addRemeditation }, { indexCommuneBanIds });
+  validateBanIds(row, { addError, addRemeditation }, { mapCodeCommuneBanIds });
 }
 
 export default validateRow;

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -1,10 +1,8 @@
 import proj from '@etalab/project-legal';
-import { v4 as uuid } from 'uuid';
 import { getCommuneActuelle } from '../utils/cog';
 import { ValidateRowType } from '../validate/validate.type';
-import { ParsedValue } from './shema.type';
 
-function getCodeCommune(row: ValidateRowType) {
+export function getCodeCommune(row: ValidateRowType) {
   return (
     row.parsedValues.commune_insee ||
     row.additionalValues?.cle_interop?.codeCommune
@@ -124,15 +122,8 @@ function validateBanIds(
   row: ValidateRowType,
   {
     addError,
-    addRemeditation,
   }: {
     addError: (code: string) => void;
-    addRemeditation: (field: string, value: ParsedValue) => void;
-  },
-  {
-    mapCodeCommuneBanIds,
-  }: {
-    mapCodeCommuneBanIds: Record<string, string>;
   },
 ) {
   const idBanCommune =
@@ -147,28 +138,15 @@ function validateBanIds(
 
   // Si au moins un des ID est présent, cela signifie que l'adresse BAL utilise BanID
   if (idBanCommune || idBanToponyme || idBanAdresse) {
-    let isLackOfIdBan = false;
     if (!idBanCommune) {
-      const codeCommune = getCodeCommune(row);
-      addRemeditation('id_ban_commune', mapCodeCommuneBanIds[codeCommune]);
-      isLackOfIdBan = true;
-    }
-    if (!idBanToponyme) {
-      addRemeditation('id_ban_toponyme', uuid());
-      isLackOfIdBan = true;
-    }
-    if (!idBanAdresse && row.parsedValues.numero !== 99_999) {
-      addRemeditation('id_ban_adresse', uuid());
-      isLackOfIdBan = true;
-    }
-    if (isLackOfIdBan) {
       addError('lack_of_id_ban');
     }
-  } else {
-    const codeCommune = getCodeCommune(row);
-    addRemeditation('id_ban_commune', mapCodeCommuneBanIds[codeCommune]);
-    addRemeditation('id_ban_toponyme', uuid());
-    addRemeditation('id_ban_adresse', uuid());
+    if (!idBanToponyme) {
+      addError('lack_of_id_ban');
+    }
+    if (!idBanAdresse && row.parsedValues.numero !== 99_999) {
+      addError('lack_of_id_ban');
+    }
   }
 }
 
@@ -176,15 +154,8 @@ function validateRow(
   row: ValidateRowType,
   {
     addError,
-    addRemeditation,
   }: {
     addError: (code: string) => void;
-    addRemeditation: (field: string, value: ParsedValue) => void;
-  },
-  {
-    mapCodeCommuneBanIds,
-  }: {
-    mapCodeCommuneBanIds: Record<string, string>;
   },
 ) {
   validateCleInterop(row, { addError });
@@ -192,7 +163,7 @@ function validateRow(
   validateCoords(row, { addError });
   validateMinimalAdress(row, { addError });
   validateCommuneDelegueeInsee(row, { addError });
-  validateBanIds(row, { addError, addRemeditation }, { mapCodeCommuneBanIds });
+  validateBanIds(row, { addError });
 }
 
 export default validateRow;

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -39,13 +39,16 @@ function validateUseBanIds(
       districtIDs.add(idBanCommune);
     }
   }
-
   if (balAdresseUseBanId === rows.length) {
     // Check district IDs consistency
     if (districtIDs.size > 1) {
       addError('rows.multi_id_ban_commune');
     }
-    if (!communeBanIds.some((districtID) => districtIDs.has(districtID))) {
+    if (
+      !Array.from(districtIDs).every((districtID: string) =>
+        communeBanIds.includes(districtID),
+      )
+    ) {
       addError('rows.cog_no_match_id_ban_commune');
     }
     return true;

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -103,6 +103,20 @@ function remediationBanIds(
   }
 }
 
+function getBanIdsFromRow(row: ValidateRowType) {
+  return {
+    idBanCommune:
+      row.parsedValues.id_ban_commune ||
+      row.additionalValues?.uid_adresse?.idBanCommune,
+    idBanToponyme:
+      row.parsedValues.id_ban_toponyme ||
+      row.additionalValues?.uid_adresse?.idBanToponyme,
+    idBanAdresse:
+      row.parsedValues.id_ban_adresse ||
+      row.additionalValues?.uid_adresse?.idBanAdresse,
+  };
+}
+
 async function validateUseBanIds(
   rows: ValidateRowType[],
   {
@@ -117,15 +131,7 @@ async function validateUseBanIds(
   let balAdresseUseBanId = 0;
 
   for (const row of rows) {
-    const idBanCommune =
-      row.parsedValues.id_ban_commune ||
-      row.additionalValues?.uid_adresse?.idBanCommune;
-    const idBanToponyme =
-      row.parsedValues.id_ban_toponyme ||
-      row.additionalValues?.uid_adresse?.idBanToponyme;
-    const idBanAdresse =
-      row.parsedValues.id_ban_adresse ||
-      row.additionalValues?.uid_adresse?.idBanAdresse;
+    const { idBanCommune, idBanToponyme, idBanAdresse } = getBanIdsFromRow(row);
     const numero = row.parsedValues.numero;
 
     if (
@@ -135,12 +141,13 @@ async function validateUseBanIds(
     ) {
       balAdresseUseBanId++;
       districtIDs.add(idBanCommune);
+    } else {
+      remediationBanIds(
+        row,
+        { idBanCommune, idBanToponyme, idBanAdresse },
+        { mapCodeCommuneBanId, mapNomVoieBanId },
+      );
     }
-    remediationBanIds(
-      row,
-      { idBanCommune, idBanToponyme, idBanAdresse },
-      { mapCodeCommuneBanId, mapNomVoieBanId },
-    );
   }
   if (balAdresseUseBanId === rows.length) {
     // Check district IDs consistency

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -1,4 +1,73 @@
 import { IS_TOPO_NB, ValidateRowType } from '../validate/validate.type';
+import { getCodeCommune } from './row';
+import { normalize } from '@ban-team/adresses-util/lib/voies';
+import { chain } from 'lodash';
+import { v4 as uuid } from 'uuid';
+
+const BAN_API_URL =
+  process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr';
+
+type DistrictBanResponse = {
+  status: 'success' | 'error';
+  response: { id: string }[];
+};
+
+export async function getCommuneBanIdByCodeCommune(
+  codeCommune: string,
+): Promise<DistrictBanResponse> {
+  const response = await fetch(
+    `${BAN_API_URL}/api/district/cog/${codeCommune}`,
+  );
+  if (!response.ok) {
+    const body = await response.json();
+    throw new Error(body.message);
+  }
+
+  return response.json();
+}
+
+export async function getMapCodeCommuneBanId(
+  parsedRows: ValidateRowType[],
+): Promise<Record<string, string>> {
+  const indexCommuneBanIds: Record<string, string> = {};
+
+  const codeCommunes = new Set<string>([
+    ...parsedRows
+      .filter(
+        ({ parsedValues, additionalValues }) =>
+          parsedValues.commune_insee ||
+          additionalValues?.cle_interop?.codeCommune,
+      )
+      .map(
+        ({ parsedValues, additionalValues }) =>
+          parsedValues.commune_insee ||
+          additionalValues?.cle_interop?.codeCommune,
+      ),
+  ]);
+
+  for (const codeCommune of Array.from(codeCommunes)) {
+    const res = await getCommuneBanIdByCodeCommune(codeCommune);
+    if (res.status == 'success' && res.response) {
+      indexCommuneBanIds[codeCommune] = res.response[0].id;
+    }
+  }
+  return indexCommuneBanIds;
+}
+
+function getMapNameVoieBanId(
+  parsedRows: ValidateRowType[],
+): Record<string, string> {
+  return chain(parsedRows)
+    .keyBy(({ parsedValues }) => normalize(parsedValues.voie_nom))
+    .map((row) => [
+      row.parsedValues.voie_nom,
+      row.parsedValues.id_ban_toponyme ||
+        row.additionalValues?.uid_adresse?.idBanToponyme ||
+        uuid(),
+    ])
+    .fromPairs()
+    .value();
+}
 
 function validateRowsEmpty(
   rows: ValidateRowType[],
@@ -10,11 +79,41 @@ function validateRowsEmpty(
   }
 }
 
-function validateUseBanIds(
-  rows: ValidateRowType[],
-  { addError }: { addError: (code: string) => void },
-  { communeBanIds }: { communeBanIds: string[] },
+function remediationBanIds(
+  row: ValidateRowType,
+  { idBanCommune, idBanToponyme, idBanAdresse },
+  {
+    mapCodeCommuneBanId,
+    mapNomVoieBanId,
+  }: {
+    mapCodeCommuneBanId: Record<string, string>;
+    mapNomVoieBanId: Record<string, string>;
+  },
 ) {
+  const codeCommune = getCodeCommune(row);
+
+  if (!idBanCommune) {
+    row.remediations.id_ban_commune = mapCodeCommuneBanId[codeCommune];
+  }
+  if (!idBanToponyme) {
+    row.remediations.id_ban_toponyme =
+      mapNomVoieBanId[normalize(row.parsedValues.voie_nom)];
+  }
+  if (!idBanAdresse && row.parsedValues.numero !== 99_999) {
+    row.remediations.id_ban_adresse = uuid();
+  }
+}
+
+async function validateUseBanIds(
+  rows: ValidateRowType[],
+  {
+    addError,
+  }: {
+    addError: (code: string) => void;
+  },
+) {
+  const mapCodeCommuneBanId = await getMapCodeCommuneBanId(rows);
+  const mapNomVoieBanId = getMapNameVoieBanId(rows);
   const districtIDs = new Set();
   let balAdresseUseBanId = 0;
 
@@ -38,6 +137,11 @@ function validateUseBanIds(
       balAdresseUseBanId++;
       districtIDs.add(idBanCommune);
     }
+    remediationBanIds(
+      row,
+      { idBanCommune, idBanToponyme, idBanAdresse },
+      { mapCodeCommuneBanId, mapNomVoieBanId },
+    );
   }
   if (balAdresseUseBanId === rows.length) {
     // Check district IDs consistency
@@ -46,7 +150,7 @@ function validateUseBanIds(
     }
     if (
       !Array.from(districtIDs).every((districtID: string) =>
-        communeBanIds.includes(districtID),
+        Object.values(mapCodeCommuneBanId).includes(districtID),
       )
     ) {
       addError('rows.cog_no_match_id_ban_commune');
@@ -57,13 +161,16 @@ function validateUseBanIds(
   }
 }
 
-function validateRows(
+async function validateRows(
   rows: ValidateRowType[],
-  { addError }: { addError: (code: string) => void },
-  { communeBanIds }: { communeBanIds: string[] },
+  {
+    addError,
+  }: {
+    addError: (code: string) => void;
+  },
 ) {
   validateRowsEmpty(rows, { addError });
-  validateUseBanIds(rows, { addError }, { communeBanIds });
+  validateUseBanIds(rows, { addError });
 }
 
 export default validateRows;

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -13,6 +13,7 @@ function validateRowsEmpty(
 function validateUseBanIds(
   rows: ValidateRowType[],
   { addError }: { addError: (code: string) => void },
+  { communeBanIds }: { communeBanIds: string[] },
 ) {
   const districtIDs = new Set();
   let balAdresseUseBanId = 0;
@@ -44,11 +45,9 @@ function validateUseBanIds(
     if (districtIDs.size > 1) {
       addError('rows.multi_id_ban_commune');
     }
-    // if (!districtIDs.has(districtID)) {
-    //   throw new Error(
-    //     `Missing rights - BAL from district ID : \`${districtID}\` (cog : \`${cog}\`) - Cannot be updated`,
-    //   );
-    // }
+    if (!communeBanIds.some((districtID) => districtIDs.has(districtID))) {
+      addError('rows.cog_no_match_id_ban_commune');
+    }
     return true;
   } else if (balAdresseUseBanId > 0) {
     addError('rows.every_line_required_id_ban');
@@ -58,9 +57,10 @@ function validateUseBanIds(
 function validateRows(
   rows: ValidateRowType[],
   { addError }: { addError: (code: string) => void },
+  { communeBanIds }: { communeBanIds: string[] },
 ) {
   validateRowsEmpty(rows, { addError });
-  validateUseBanIds(rows, { addError });
+  validateUseBanIds(rows, { addError }, { communeBanIds });
 }
 
 export default validateRows;

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -60,7 +60,7 @@ function getMapNameVoieBanId(
   return chain(parsedRows)
     .keyBy(({ parsedValues }) => normalize(parsedValues.voie_nom))
     .map((row) => [
-      row.parsedValues.voie_nom,
+      normalize(row.parsedValues.voie_nom),
       row.parsedValues.id_ban_toponyme ||
         row.additionalValues?.uid_adresse?.idBanToponyme ||
         uuid(),
@@ -91,7 +91,6 @@ function remediationBanIds(
   },
 ) {
   const codeCommune = getCodeCommune(row);
-
   if (!idBanCommune) {
     row.remediations.id_ban_commune = mapCodeCommuneBanId[codeCommune];
   }
@@ -170,7 +169,7 @@ async function validateRows(
   },
 ) {
   validateRowsEmpty(rows, { addError });
-  validateUseBanIds(rows, { addError });
+  await validateUseBanIds(rows, { addError });
 }
 
 export default validateRows;

--- a/lib/validate/__tests__/1.4/data/1.4-cog-no-match-id_ban_commune.csv
+++ b/lib/validate/__tests__/1.4/data/1.4-cog-no-match-id_ban_commune.csv
@@ -1,0 +1,3 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842a;8a3bab10-f329-4ce3-9c7d-280d91a8053a;3c87abe4-887b-46ee-9192-5c1b35a06625;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09
+31591_xxxx_00009;0246e48c-f33d-433a-8984-034219be842e;8a3bab10-f329-4ce3-9c7d-280d91a8053a;3c87abe4-887b-46ee-9192-5c1b35a06625;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/lib/validate/__tests__/1.4/index.spec.ts
+++ b/lib/validate/__tests__/1.4/index.spec.ts
@@ -18,7 +18,10 @@ function readAsBuffer(relativePath) {
 describe('VALIDATE 1.4 TEST', () => {
   beforeEach(() => {
     fetchMock.doMock(async () => {
-      return JSON.stringify([{ id: '0246e48c-f33d-433a-8984-034219be842e' }]);
+      return JSON.stringify({
+        status: 'success',
+        response: [{ id: '0246e48c-f33d-433a-8984-034219be842e' }],
+      });
     });
   });
 

--- a/lib/validate/__tests__/1.4/index.spec.ts
+++ b/lib/validate/__tests__/1.4/index.spec.ts
@@ -17,8 +17,7 @@ function readAsBuffer(relativePath) {
 
 describe('VALIDATE 1.4 TEST', () => {
   beforeEach(() => {
-    fetchMock.doMock(async (req) => {
-      console.log(req.url);
+    fetchMock.doMock(async () => {
       return JSON.stringify([{ id: '0246e48c-f33d-433a-8984-034219be842e' }]);
     });
   });
@@ -32,6 +31,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(true);
   });
+
   test('Valid file 1.4', async () => {
     const buffer = await readAsBuffer('1.4-valid.csv');
     const report = (await validate(buffer, {
@@ -41,6 +41,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(true);
   });
+
   test('Valid file 1.4 with relaxFieldsDetection', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
@@ -50,6 +51,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
+
   test('Valid file 1.4 with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
@@ -60,6 +62,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
+
   test('Error file 1.4 without relaxFieldsDetection', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
@@ -70,6 +73,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
+
   test('Error file 1.4 with profile 1.4', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
@@ -79,6 +83,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
+
   test('Error bad id ban adresses (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-adresse.csv');
     const report = (await validate(buffer, {
@@ -93,6 +98,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Error bad id ban commune (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-commune.csv');
     const report = (await validate(buffer, {
@@ -107,6 +113,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Error bad id ban toponyme a (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-toponyme.csv');
     const report = (await validate(buffer, {
@@ -121,6 +128,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Good incoherent dependance ban id (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-incoherent-dependance-id-ban.csv');
     const report = (await validate(buffer, {
@@ -130,6 +138,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
+
   test('Error incoherent dependance ban id (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-dependance-id-ban.csv');
     const report = (await validate(buffer, {
@@ -144,6 +153,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Warning adresses_required_id_ban (file 1.4) with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-without-ban-adresse.csv');
     const report = (await validate(buffer, {
@@ -158,6 +168,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('ERROR adresses_required_id_ban (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-without-ban-adresse.csv');
     const report = (await validate(buffer, {
@@ -172,6 +183,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Valid file 1.4 with ids ban empty', async () => {
     const buffer = await readAsBuffer('1.4-ids-ban-empty.csv');
     const report = (await validate(buffer, {
@@ -183,6 +195,7 @@ describe('VALIDATE 1.4 TEST', () => {
     );
     expect(error.length).toBe(0);
   });
+
   test('Warning rows.every_line_required_id_ban (file 1.4) with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv');
     const report = (await validate(buffer, {
@@ -197,6 +210,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Warning rows.every_line_required_id_ban (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv');
     const report = (await validate(buffer, {
@@ -211,6 +225,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Read uid_adresse', async () => {
     const buffer = await readAsBuffer('1.3-valid-uid_adresse.csv');
     const report = (await validate(buffer, {
@@ -229,6 +244,7 @@ describe('VALIDATE 1.4 TEST', () => {
       '3c87abe4-887b-46ee-9192-5c1b35a06625',
     );
   });
+
   test('Error uid_adresse type invalide', async () => {
     const buffer = await readAsBuffer('1.3-invalid-uid_adresse.csv');
     const report = (await validate(buffer, {
@@ -243,6 +259,7 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
+
   test('Error uid_adresse incoherence_id_ban', async () => {
     const buffer = await readAsBuffer('1.3-incoherent-uid_adresse.csv');
     const report = (await validate(buffer, {
@@ -253,6 +270,21 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
     const error = report.profilErrors.filter(
       (e) => e.code === 'row.lack_of_id_ban',
+    );
+    expect(error.length).toBe(1);
+    expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
+  });
+
+  test('Error cog_no_match_id_ban_commune', async () => {
+    const buffer = await readAsBuffer('1.4-cog-no-match-id_ban_commune.csv');
+    const report = (await validate(buffer, {
+      profile: '1.4',
+    })) as ValidateType;
+    expect(report.encoding).toBe('utf-8');
+    expect(report.parseOk).toBe(true);
+    expect(report.profilesValidation['1.4'].isValid).toBe(false);
+    const error = report.profilErrors.filter(
+      (e) => e.code === 'rows.cog_no_match_id_ban_commune',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);

--- a/lib/validate/__tests__/1.4/index.spec.ts
+++ b/lib/validate/__tests__/1.4/index.spec.ts
@@ -1,9 +1,12 @@
 import { join } from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
 import { validate } from '../../index';
 import { ValidateType } from '../../validate.type';
 import { ErrorLevelEnum } from '../../../utils/helpers';
+
+enableFetchMocks();
 
 const readFile = promisify(fs.readFile);
 
@@ -13,6 +16,13 @@ function readAsBuffer(relativePath) {
 }
 
 describe('VALIDATE 1.4 TEST', () => {
+  beforeEach(() => {
+    fetchMock.doMock(async (req) => {
+      console.log(req.url);
+      return JSON.stringify([{ id: '0246e48c-f33d-433a-8984-034219be842e' }]);
+    });
+  });
+
   test('Valid file 1.3', async () => {
     const buffer = await readAsBuffer('1.3-valid.csv');
     const report = (await validate(buffer, {
@@ -20,10 +30,8 @@ describe('VALIDATE 1.4 TEST', () => {
     })) as ValidateType;
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
-
     expect(report.profilesValidation['1.4'].isValid).toBe(true);
   });
-
   test('Valid file 1.4', async () => {
     const buffer = await readAsBuffer('1.4-valid.csv');
     const report = (await validate(buffer, {
@@ -33,214 +41,176 @@ describe('VALIDATE 1.4 TEST', () => {
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(true);
   });
-
   test('Valid file 1.4 with relaxFieldsDetection', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
       relaxFieldsDetection: true,
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
-
   test('Valid file 1.4 with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
       relaxFieldsDetection: true,
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
-
   test('Error file 1.4 without relaxFieldsDetection', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
       relaxFieldsDetection: false,
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
-
   test('Error file 1.4 with profile 1.4', async () => {
     const buffer = await readAsBuffer('1.4-valid-relax.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
-
   test('Error bad id ban adresses (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-adresse.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'id_ban_adresse.type_invalide',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Error bad id ban commune (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-commune.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'id_ban_commune.type_invalide',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Error bad id ban toponyme a (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-id-ban-toponyme.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'id_ban_toponyme.type_invalide',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Good incoherent dependance ban id (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-incoherent-dependance-id-ban.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
   });
-
   test('Error incoherent dependance ban id (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-bad-dependance-id-ban.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'row.lack_of_id_ban',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Warning adresses_required_id_ban (file 1.4) with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-without-ban-adresse.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'row.lack_of_id_ban',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('ERROR adresses_required_id_ban (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-without-ban-adresse.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'row.lack_of_id_ban',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Valid file 1.4 with ids ban empty', async () => {
     const buffer = await readAsBuffer('1.4-ids-ban-empty.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.profilesValidation['1.4'].isValid).toBe(true);
-
     const error = report.profilErrors.filter(
       (e) => e.level === ErrorLevelEnum.ERROR,
     );
     expect(error.length).toBe(0);
   });
-
   test('Warning rows.every_line_required_id_ban (file 1.4) with profile relax', async () => {
     const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'rows.every_line_required_id_ban',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Warning rows.every_line_required_id_ban (file 1.4)', async () => {
     const buffer = await readAsBuffer('1.4-no-ids-ban-every.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'rows.every_line_required_id_ban',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Read uid_adresse', async () => {
     const buffer = await readAsBuffer('1.3-valid-uid_adresse.csv');
     const report = (await validate(buffer, {
@@ -259,34 +229,28 @@ describe('VALIDATE 1.4 TEST', () => {
       '3c87abe4-887b-46ee-9192-5c1b35a06625',
     );
   });
-
   test('Error uid_adresse type invalide', async () => {
     const buffer = await readAsBuffer('1.3-invalid-uid_adresse.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'uid_adresse.type_invalide',
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
   });
-
   test('Error uid_adresse incoherence_id_ban', async () => {
     const buffer = await readAsBuffer('1.3-incoherent-uid_adresse.csv');
     const report = (await validate(buffer, {
       profile: '1.4',
     })) as ValidateType;
-
     expect(report.encoding).toBe('utf-8');
     expect(report.parseOk).toBe(true);
     expect(report.profilesValidation['1.4'].isValid).toBe(false);
-
     const error = report.profilErrors.filter(
       (e) => e.code === 'row.lack_of_id_ban',
     );

--- a/lib/validate/__tests__/1.4/index.spec.ts
+++ b/lib/validate/__tests__/1.4/index.spec.ts
@@ -155,6 +155,8 @@ describe('VALIDATE 1.4 TEST', () => {
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
+    // CHECK REMEDIATION
+    expect(report.rows[0].remediations).toHaveProperty('id_ban_commune');
   });
 
   test('Warning adresses_required_id_ban (file 1.4) with profile relax', async () => {
@@ -170,6 +172,8 @@ describe('VALIDATE 1.4 TEST', () => {
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
+    // CHECK REMEDIATION
+    expect(report.rows[0].remediations).toHaveProperty('id_ban_adresse');
   });
 
   test('ERROR adresses_required_id_ban (file 1.4)', async () => {
@@ -185,6 +189,8 @@ describe('VALIDATE 1.4 TEST', () => {
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
+    // CHECK REMEDIATION
+    expect(report.rows[0].remediations).toHaveProperty('id_ban_adresse');
   });
 
   test('Valid file 1.4 with ids ban empty', async () => {
@@ -196,6 +202,12 @@ describe('VALIDATE 1.4 TEST', () => {
     const error = report.profilErrors.filter(
       (e) => e.level === ErrorLevelEnum.ERROR,
     );
+    // CHECK REMEDIATION
+    for (const row of report.rows) {
+      expect(row.remediations).toHaveProperty('id_ban_commune');
+      expect(row.remediations).toHaveProperty('id_ban_toponyme');
+      expect(row.remediations).toHaveProperty('id_ban_adresse');
+    }
     expect(error.length).toBe(0);
   });
 
@@ -276,6 +288,8 @@ describe('VALIDATE 1.4 TEST', () => {
     );
     expect(error.length).toBe(1);
     expect(error[0].level).toBe(ErrorLevelEnum.ERROR);
+    // CHECK REMEDIATION
+    expect(report.rows[0].remediations).toHaveProperty('id_ban_commune');
   });
 
   test('Error cog_no_match_id_ban_commune', async () => {

--- a/lib/validate/__tests__/index.spec.ts
+++ b/lib/validate/__tests__/index.spec.ts
@@ -1,9 +1,11 @@
 import { join } from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
-
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
 import { validate } from '..';
 import { ValidateType } from '../validate.type';
+
+enableFetchMocks();
 
 const readFile = promisify(fs.readFile);
 
@@ -13,6 +15,12 @@ function readAsBuffer(relativePath) {
 }
 
 describe('VALIDATE TEST', () => {
+  beforeEach(() => {
+    fetchMock.doMock(async () => {
+      return JSON.stringify([{ id: '0246e48c-f33d-433a-8984-034219be842e' }]);
+    });
+  });
+
   it('validate a file', async () => {
     const buffer = await readAsBuffer('sample.csv');
     const report = await validate(buffer);

--- a/lib/validate/__tests__/index.spec.ts
+++ b/lib/validate/__tests__/index.spec.ts
@@ -17,7 +17,10 @@ function readAsBuffer(relativePath) {
 describe('VALIDATE TEST', () => {
   beforeEach(() => {
     fetchMock.doMock(async () => {
-      return JSON.stringify([{ id: '0246e48c-f33d-433a-8984-034219be842e' }]);
+      return JSON.stringify({
+        status: 'success',
+        response: [{ id: '0246e48c-f33d-433a-8984-034219be842e' }],
+      });
     });
   });
 

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -48,10 +48,12 @@ function getMultiLangField(
   parsedValues: ParsedValues,
   fieldName: string,
 ) {
-  const fieldMultiLang = fields.filter(
-    ({ schemaName, locale }) =>
-      schemaName === fieldName && langs.includes(locale),
-  );
+  const fieldMultiLang = fields
+    .filter(
+      ({ schemaName, locale }) =>
+        schemaName === fieldName && langs.includes(locale),
+    )
+    .map(({ localizedSchemaName }) => localizedSchemaName);
 
   return pick(parsedValues, fieldMultiLang);
 }

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -10,32 +10,35 @@ function getIdsBan(
   fields: FieldType[],
   parsedValues: ParsedValues,
   remediations: ParsedValues,
+  additionalValues: Record<string, any>,
 ) {
   if (
     fields.some(({ schemaName }) => schemaName === 'id_ban_commune') ||
     fields.some(({ schemaName }) => schemaName === 'id_ban_toponyme') ||
     fields.some(({ schemaName }) => schemaName === 'id_ban_adresse')
   ) {
+    const idBanCommune =
+      remediations.id_ban_commune || parsedValues.id_ban_commune;
+    const idBanToponyme =
+      remediations.id_ban_toponyme || parsedValues.id_ban_toponyme;
+    const idBanAdresse =
+      remediations.id_ban_adresse || parsedValues.id_ban_adresse;
     return {
-      id_ban_commune:
-        remediations.id_ban_commune || parsedValues.id_ban_commune,
-      id_ban_toponyme:
-        remediations.id_ban_toponyme || parsedValues.id_ban_toponyme,
-      id_ban_adresse:
-        remediations.id_ban_adresse || parsedValues.id_ban_adresse,
+      id_ban_commune: idBanCommune,
+      id_ban_toponyme: idBanToponyme,
+      id_ban_adresse: idBanAdresse,
     };
   } else if (fields.some(({ schemaName }) => schemaName === 'uid_adresse')) {
-    let uid_adresse = parsedValues.uid_adresse;
-    if (remediations.id_ban_commune) {
-      uid_adresse = uid_adresse.concat(` @c:${remediations.id_ban_commune} `);
-    }
-    if (remediations.id_ban_toponyme) {
-      uid_adresse = uid_adresse.concat(` @v:${remediations.id_ban_commune} `);
-    }
-    if (remediations.id_ban_adresse) {
-      uid_adresse = uid_adresse.concat(` @a:${remediations.id_ban_commune} `);
-    }
-    return { uid_adresse };
+    const idBanCommune =
+      remediations.id_ban_commune || additionalValues.uid_adresse.idBanCommune;
+    const idBanToponyme =
+      remediations.id_ban_toponyme ||
+      additionalValues.uid_adresse.idBanToponyme;
+    const idBanAdresse =
+      remediations.id_ban_adresse || additionalValues.uid_adresse.idBanAdresse;
+    return {
+      uid_adresse: `@c:${idBanCommune} @v:${idBanToponyme} @a:${idBanAdresse}`,
+    };
   }
   return {};
 }
@@ -55,10 +58,10 @@ function getMultiLangField(
 
 function getCsvRow(
   fields: FieldType[],
-  { parsedValues, remediations }: ValidateRowType,
+  { parsedValues, remediations, additionalValues }: ValidateRowType,
 ): ParsedValues {
   return {
-    ...getIdsBan(fields, parsedValues, remediations),
+    ...getIdsBan(fields, parsedValues, remediations, additionalValues),
     cle_interop: remediations.cle_interop || parsedValues.cle_interop,
     commune_insee: remediations.commune_insee || parsedValues.commune_insee,
     commune_nom: remediations.commune_nom || parsedValues.commune_nom,

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -15,29 +15,25 @@ function getIdsBan(
   if (
     fields.some(({ schemaName }) => schemaName === 'id_ban_commune') ||
     fields.some(({ schemaName }) => schemaName === 'id_ban_toponyme') ||
-    fields.some(({ schemaName }) => schemaName === 'id_ban_adresse')
+    fields.some(({ schemaName }) => schemaName === 'id_ban_adresse') ||
+    fields.some(({ schemaName }) => schemaName === 'uid_adresse')
   ) {
     const idBanCommune =
-      remediations.id_ban_commune || parsedValues.id_ban_commune;
+      remediations.id_ban_commune ||
+      parsedValues.id_ban_commune ||
+      additionalValues.uid_adresse.idBanCommune;
     const idBanToponyme =
-      remediations.id_ban_toponyme || parsedValues.id_ban_toponyme;
+      remediations.id_ban_toponyme ||
+      parsedValues.id_ban_toponyme ||
+      additionalValues.uid_adresse.idBanToponyme;
     const idBanAdresse =
-      remediations.id_ban_adresse || parsedValues.id_ban_adresse;
+      remediations.id_ban_adresse ||
+      parsedValues.id_ban_adresse ||
+      additionalValues.uid_adresse.idBanAdresse;
     return {
       id_ban_commune: idBanCommune,
       id_ban_toponyme: idBanToponyme,
       id_ban_adresse: idBanAdresse,
-    };
-  } else if (fields.some(({ schemaName }) => schemaName === 'uid_adresse')) {
-    const idBanCommune =
-      remediations.id_ban_commune || additionalValues.uid_adresse.idBanCommune;
-    const idBanToponyme =
-      remediations.id_ban_toponyme ||
-      additionalValues.uid_adresse.idBanToponyme;
-    const idBanAdresse =
-      remediations.id_ban_adresse || additionalValues.uid_adresse.idBanAdresse;
-    return {
-      uid_adresse: `@c:${idBanCommune} @v:${idBanToponyme} @a:${idBanAdresse}`,
     };
   }
   return {};

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -7,36 +7,27 @@ import { ParsedValues } from '../schema/shema.type';
 const langs = languesRegionales.map(({ code }) => code);
 
 function getIdsBan(
-  fields: FieldType[],
   parsedValues: ParsedValues,
   remediations: ParsedValues,
   additionalValues: Record<string, any>,
 ) {
-  if (
-    fields.some(({ schemaName }) => schemaName === 'id_ban_commune') ||
-    fields.some(({ schemaName }) => schemaName === 'id_ban_toponyme') ||
-    fields.some(({ schemaName }) => schemaName === 'id_ban_adresse') ||
-    fields.some(({ schemaName }) => schemaName === 'uid_adresse')
-  ) {
-    const idBanCommune =
-      remediations.id_ban_commune ||
-      parsedValues.id_ban_commune ||
-      additionalValues.uid_adresse.idBanCommune;
-    const idBanToponyme =
-      remediations.id_ban_toponyme ||
-      parsedValues.id_ban_toponyme ||
-      additionalValues.uid_adresse.idBanToponyme;
-    const idBanAdresse =
-      remediations.id_ban_adresse ||
-      parsedValues.id_ban_adresse ||
-      additionalValues.uid_adresse.idBanAdresse;
-    return {
-      id_ban_commune: idBanCommune,
-      id_ban_toponyme: idBanToponyme,
-      id_ban_adresse: idBanAdresse,
-    };
-  }
-  return {};
+  const idBanCommune =
+    remediations.id_ban_commune ||
+    parsedValues.id_ban_commune ||
+    additionalValues.uid_adresse.idBanCommune;
+  const idBanToponyme =
+    remediations.id_ban_toponyme ||
+    parsedValues.id_ban_toponyme ||
+    additionalValues.uid_adresse.idBanToponyme;
+  const idBanAdresse =
+    remediations.id_ban_adresse ||
+    parsedValues.id_ban_adresse ||
+    additionalValues.uid_adresse.idBanAdresse;
+  return {
+    id_ban_commune: idBanCommune,
+    id_ban_toponyme: idBanToponyme,
+    id_ban_adresse: idBanAdresse,
+  };
 }
 
 function getMultiLangField(
@@ -59,7 +50,7 @@ function getCsvRow(
   { parsedValues, remediations, additionalValues }: ValidateRowType,
 ): ParsedValues {
   return {
-    ...getIdsBan(fields, parsedValues, remediations, additionalValues),
+    ...getIdsBan(parsedValues, remediations, additionalValues),
     cle_interop: remediations.cle_interop || parsedValues.cle_interop,
     commune_insee: remediations.commune_insee || parsedValues.commune_insee,
     commune_nom: remediations.commune_nom || parsedValues.commune_nom,

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -1,0 +1,14 @@
+import Papa from 'papaparse';
+import { PrevalidateType } from './validate.type';
+import { ParsedValues } from '../schema/shema.type';
+
+export function exportCsvBALWithReport({ rows }: PrevalidateType): Buffer {
+  const csvRows: ParsedValues[] = rows.map(({ parsedValues, remediations }) => {
+    return {
+      ...parsedValues,
+      ...remediations,
+    };
+  });
+  const csvData = Papa.unparse(csvRows, { delimiter: ';' });
+  return Buffer.from(csvData);
+}

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -1,14 +1,85 @@
 import Papa from 'papaparse';
-import { PrevalidateType } from './validate.type';
+import languesRegionales from '@ban-team/shared-data/langues-regionales.json';
+import { PrevalidateType, ValidateRowType } from './validate.type';
 import { ParsedValues } from '../schema/shema.type';
 
-export function exportCsvBALWithReport({ rows }: PrevalidateType): Buffer {
-  const csvRows: ParsedValues[] = rows.map(({ parsedValues, remediations }) => {
+function getIdsBan(parsedValues: ParsedValues, remediations: ParsedValues) {
+  if (
+    parsedValues.id_ban_commune ||
+    parsedValues.id_ban_toponyme ||
+    parsedValues.id_ban_adresse
+  ) {
     return {
-      ...parsedValues,
-      ...remediations,
+      id_ban_commune:
+        remediations.id_ban_commune || parsedValues.id_ban_commune,
+      id_ban_toponyme:
+        remediations.id_ban_toponyme || parsedValues.id_ban_toponyme,
+      id_ban_adresse:
+        remediations.id_ban_adresse || parsedValues.id_ban_adresse,
     };
-  });
+  } else if (parsedValues.uid_adresse) {
+    const uid_adresse = parsedValues.uid_adresse;
+    if (remediations.id_ban_commune) {
+      uid_adresse.concat(` @c:${remediations.id_ban_commune} `);
+    }
+    if (remediations.id_ban_toponyme) {
+      uid_adresse.concat(` @v:${remediations.id_ban_commune} `);
+    }
+    if (remediations.id_ban_adresse) {
+      uid_adresse.concat(` @a:${remediations.id_ban_commune} `);
+    }
+    return { uid_adresse };
+  }
+  return {};
+}
+
+function getMultiLangField(parsedValues: ParsedValues, fieldName: string) {
+  return Object.fromEntries(
+    Object.entries(parsedValues).filter(([key]) =>
+      languesRegionales.some(({ code }) => key === `${fieldName}_${code}`),
+    ),
+  );
+}
+
+function getCsvRow({
+  parsedValues,
+  remediations,
+}: ValidateRowType): ParsedValues {
+  return {
+    ...getIdsBan(parsedValues, remediations),
+    cle_interop: remediations.cle_interop || parsedValues.cle_interop,
+    commune_insee: remediations.commune_insee || parsedValues.commune_insee,
+    commune_nom: remediations.commune_nom || parsedValues.commune_nom,
+    ...getMultiLangField(parsedValues, 'commune_nom'),
+    commune_deleguee_insee:
+      remediations.commune_deleguee_insee ||
+      parsedValues.commune_deleguee_insee,
+    commune_deleguee_nom:
+      remediations.commune_deleguee_nom || parsedValues.commune_deleguee_nom,
+    ...getMultiLangField(parsedValues, 'commune_deleguee_nom'),
+    voie_nom: remediations.voie_nom || parsedValues.voie_nom,
+    ...getMultiLangField(parsedValues, 'voie_nom'),
+    lieudit_complement_nom:
+      remediations.lieudit_complement_nom ||
+      parsedValues.lieudit_complement_nom,
+    ...getMultiLangField(parsedValues, 'lieudit_complement_nom'),
+    numero: remediations.numero || parsedValues.numero,
+    suffixe: remediations.suffixe || parsedValues.suffixe,
+    position: remediations.position || parsedValues.position,
+    x: remediations.x || parsedValues.x,
+    y: remediations.y || parsedValues.y,
+    long: remediations.long || parsedValues.long,
+    lat: remediations.lat || parsedValues.lat,
+    cad_parcelles: remediations.cad_parcelles || parsedValues.cad_parcelles,
+    source: remediations.source || parsedValues.source,
+    date_der_maj: remediations.date_der_maj || parsedValues.date_der_maj,
+    certification_commune:
+      remediations.certification_commune || parsedValues.certification_commune,
+  };
+}
+
+export function exportCsvBALWithReport({ rows }: PrevalidateType): Buffer {
+  const csvRows: ParsedValues[] = rows.map((r) => getCsvRow(r));
   const csvData = Papa.unparse(csvRows, { delimiter: ';' });
   return Buffer.from(csvData);
 }

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -14,15 +14,15 @@ function getIdsBan(
   const idBanCommune =
     remediations.id_ban_commune ||
     parsedValues.id_ban_commune ||
-    additionalValues.uid_adresse.idBanCommune;
+    additionalValues?.uid_adresse?.idBanToponyme;
   const idBanToponyme =
     remediations.id_ban_toponyme ||
     parsedValues.id_ban_toponyme ||
-    additionalValues.uid_adresse.idBanToponyme;
+    additionalValues?.uid_adresse?.idBanToponyme;
   const idBanAdresse =
     remediations.id_ban_adresse ||
     parsedValues.id_ban_adresse ||
-    additionalValues.uid_adresse.idBanAdresse;
+    additionalValues?.uid_adresse?.idBanToponyme;
   return {
     id_ban_commune: idBanCommune,
     id_ban_toponyme: idBanToponyme,

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -1,7 +1,10 @@
 import Papa from 'papaparse';
+import { pick } from 'lodash';
 import languesRegionales from '@ban-team/shared-data/langues-regionales.json';
 import { FieldType, PrevalidateType, ValidateRowType } from './validate.type';
 import { ParsedValues } from '../schema/shema.type';
+
+const langs = languesRegionales.map(({ code }) => code);
 
 function getIdsBan(
   fields: FieldType[],
@@ -37,13 +40,18 @@ function getIdsBan(
   return {};
 }
 
-// function getMultiLangField(parsedValues: ParsedValues, fieldName: string) {
-//   return Object.fromEntries(
-//     Object.entries(parsedValues).filter(([key]) =>
-//       languesRegionales.some(({ code }) => key === `${fieldName}_${code}`),
-//     ),
-//   );
-// }
+function getMultiLangField(
+  fields: FieldType[],
+  parsedValues: ParsedValues,
+  fieldName: string,
+) {
+  const fieldMultiLang = fields.filter(
+    ({ schemaName, locale }) =>
+      schemaName === fieldName && langs.includes(locale),
+  );
+
+  return pick(parsedValues, fieldMultiLang);
+}
 
 function getCsvRow(
   fields: FieldType[],
@@ -54,19 +62,19 @@ function getCsvRow(
     cle_interop: remediations.cle_interop || parsedValues.cle_interop,
     commune_insee: remediations.commune_insee || parsedValues.commune_insee,
     commune_nom: remediations.commune_nom || parsedValues.commune_nom,
-    // ...getMultiLangField(parsedValues, 'commune_nom'),
+    ...getMultiLangField(fields, parsedValues, 'commune_nom'),
     commune_deleguee_insee:
       remediations.commune_deleguee_insee ||
       parsedValues.commune_deleguee_insee,
     commune_deleguee_nom:
       remediations.commune_deleguee_nom || parsedValues.commune_deleguee_nom,
-    // ...getMultiLangField(parsedValues, 'commune_deleguee_nom'),
+    ...getMultiLangField(fields, parsedValues, 'commune_deleguee_nom'),
     voie_nom: remediations.voie_nom || parsedValues.voie_nom,
-    // ...getMultiLangField(parsedValues, 'voie_nom'),
+    ...getMultiLangField(fields, parsedValues, 'voie_nom'),
     lieudit_complement_nom:
       remediations.lieudit_complement_nom ||
       parsedValues.lieudit_complement_nom,
-    // ...getMultiLangField(parsedValues, 'lieudit_complement_nom'),
+    ...getMultiLangField(fields, parsedValues, 'lieudit_complement_nom'),
     numero: remediations.numero || parsedValues.numero,
     suffixe: remediations.suffixe || parsedValues.suffixe,
     position: remediations.position || parsedValues.position,

--- a/lib/validate/csv.ts
+++ b/lib/validate/csv.ts
@@ -1,13 +1,17 @@
 import Papa from 'papaparse';
 import languesRegionales from '@ban-team/shared-data/langues-regionales.json';
-import { PrevalidateType, ValidateRowType } from './validate.type';
+import { FieldType, PrevalidateType, ValidateRowType } from './validate.type';
 import { ParsedValues } from '../schema/shema.type';
 
-function getIdsBan(parsedValues: ParsedValues, remediations: ParsedValues) {
+function getIdsBan(
+  fields: FieldType[],
+  parsedValues: ParsedValues,
+  remediations: ParsedValues,
+) {
   if (
-    parsedValues.id_ban_commune ||
-    parsedValues.id_ban_toponyme ||
-    parsedValues.id_ban_adresse
+    fields.some(({ schemaName }) => schemaName === 'id_ban_commune') ||
+    fields.some(({ schemaName }) => schemaName === 'id_ban_toponyme') ||
+    fields.some(({ schemaName }) => schemaName === 'id_ban_adresse')
   ) {
     return {
       id_ban_commune:
@@ -17,52 +21,52 @@ function getIdsBan(parsedValues: ParsedValues, remediations: ParsedValues) {
       id_ban_adresse:
         remediations.id_ban_adresse || parsedValues.id_ban_adresse,
     };
-  } else if (parsedValues.uid_adresse) {
-    const uid_adresse = parsedValues.uid_adresse;
+  } else if (fields.some(({ schemaName }) => schemaName === 'uid_adresse')) {
+    let uid_adresse = parsedValues.uid_adresse;
     if (remediations.id_ban_commune) {
-      uid_adresse.concat(` @c:${remediations.id_ban_commune} `);
+      uid_adresse = uid_adresse.concat(` @c:${remediations.id_ban_commune} `);
     }
     if (remediations.id_ban_toponyme) {
-      uid_adresse.concat(` @v:${remediations.id_ban_commune} `);
+      uid_adresse = uid_adresse.concat(` @v:${remediations.id_ban_commune} `);
     }
     if (remediations.id_ban_adresse) {
-      uid_adresse.concat(` @a:${remediations.id_ban_commune} `);
+      uid_adresse = uid_adresse.concat(` @a:${remediations.id_ban_commune} `);
     }
     return { uid_adresse };
   }
   return {};
 }
 
-function getMultiLangField(parsedValues: ParsedValues, fieldName: string) {
-  return Object.fromEntries(
-    Object.entries(parsedValues).filter(([key]) =>
-      languesRegionales.some(({ code }) => key === `${fieldName}_${code}`),
-    ),
-  );
-}
+// function getMultiLangField(parsedValues: ParsedValues, fieldName: string) {
+//   return Object.fromEntries(
+//     Object.entries(parsedValues).filter(([key]) =>
+//       languesRegionales.some(({ code }) => key === `${fieldName}_${code}`),
+//     ),
+//   );
+// }
 
-function getCsvRow({
-  parsedValues,
-  remediations,
-}: ValidateRowType): ParsedValues {
+function getCsvRow(
+  fields: FieldType[],
+  { parsedValues, remediations }: ValidateRowType,
+): ParsedValues {
   return {
-    ...getIdsBan(parsedValues, remediations),
+    ...getIdsBan(fields, parsedValues, remediations),
     cle_interop: remediations.cle_interop || parsedValues.cle_interop,
     commune_insee: remediations.commune_insee || parsedValues.commune_insee,
     commune_nom: remediations.commune_nom || parsedValues.commune_nom,
-    ...getMultiLangField(parsedValues, 'commune_nom'),
+    // ...getMultiLangField(parsedValues, 'commune_nom'),
     commune_deleguee_insee:
       remediations.commune_deleguee_insee ||
       parsedValues.commune_deleguee_insee,
     commune_deleguee_nom:
       remediations.commune_deleguee_nom || parsedValues.commune_deleguee_nom,
-    ...getMultiLangField(parsedValues, 'commune_deleguee_nom'),
+    // ...getMultiLangField(parsedValues, 'commune_deleguee_nom'),
     voie_nom: remediations.voie_nom || parsedValues.voie_nom,
-    ...getMultiLangField(parsedValues, 'voie_nom'),
+    // ...getMultiLangField(parsedValues, 'voie_nom'),
     lieudit_complement_nom:
       remediations.lieudit_complement_nom ||
       parsedValues.lieudit_complement_nom,
-    ...getMultiLangField(parsedValues, 'lieudit_complement_nom'),
+    // ...getMultiLangField(parsedValues, 'lieudit_complement_nom'),
     numero: remediations.numero || parsedValues.numero,
     suffixe: remediations.suffixe || parsedValues.suffixe,
     position: remediations.position || parsedValues.position,
@@ -78,8 +82,11 @@ function getCsvRow({
   };
 }
 
-export function exportCsvBALWithReport({ rows }: PrevalidateType): Buffer {
-  const csvRows: ParsedValues[] = rows.map((r) => getCsvRow(r));
+export function exportCsvBALWithReport({
+  rows,
+  fields,
+}: PrevalidateType): Buffer {
+  const csvRows: ParsedValues[] = rows.map((r) => getCsvRow(fields, r));
   const csvData = Papa.unparse(csvRows, { delimiter: ';' });
   return Buffer.from(csvData);
 }

--- a/lib/validate/index.ts
+++ b/lib/validate/index.ts
@@ -16,11 +16,12 @@ import {
   ValidateRowType,
 } from './validate.type';
 import { ParseFileType } from './parse/parse.type';
+import { exportCsvBALWithReport } from './csv';
 
 export async function prevalidate(
   file: Buffer,
-  format: string,
-  relaxFieldsDetection: boolean,
+  format: string = '1.4',
+  relaxFieldsDetection: boolean = false,
 ): Promise<ParseFileType | PrevalidateType> {
   const globalErrors = new Set<string>();
   const rowsErrors = new Set<string>();
@@ -122,4 +123,15 @@ export async function validate(
   }
 
   return validateProfile(prevalidateResult as PrevalidateType, profile);
+}
+
+export async function autofix(file: Buffer): Promise<Buffer> {
+  const prevalidateResult: PrevalidateType | ParseFileType =
+    await prevalidate(file);
+
+  if (!prevalidateResult.parseOk) {
+    return null;
+  }
+
+  return exportCsvBALWithReport(prevalidateResult as PrevalidateType);
 }

--- a/lib/validate/rows.ts
+++ b/lib/validate/rows.ts
@@ -8,9 +8,14 @@ import { ParsedValues, ParsedValue, ReadValueType } from '../schema/shema.type';
 const BAN_API_URL =
   process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr';
 
+type DistrictBanRsponse = {
+  status: 'success' | 'error';
+  response: { id: string }[];
+};
+
 export async function getCommuneBanIdByCodeCommune(
   codeCommune: string,
-): Promise<{ id: string }[]> {
+): Promise<DistrictBanRsponse> {
   const response = await fetch(
     `${BAN_API_URL}/api/district/cog/${codeCommune}`,
   );
@@ -37,10 +42,10 @@ export async function getCommuneBanIds(
     }
   }
   for (const codeCommune of Array.from(codeCommunes)) {
-    const [{ id: communeBanId }] =
-      await getCommuneBanIdByCodeCommune(codeCommune);
-
-    indexCommuneBanIds[codeCommune] = communeBanId;
+    const res = await getCommuneBanIdByCodeCommune(codeCommune);
+    if (res.status == 'success' && res.response) {
+      indexCommuneBanIds[codeCommune] = res.response[0].id;
+    }
   }
   return indexCommuneBanIds;
 }

--- a/lib/validate/rows.ts
+++ b/lib/validate/rows.ts
@@ -8,14 +8,14 @@ import { ParsedValues, ParsedValue, ReadValueType } from '../schema/shema.type';
 const BAN_API_URL =
   process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr';
 
-type DistrictBanRsponse = {
+type DistrictBanResponse = {
   status: 'success' | 'error';
   response: { id: string }[];
 };
 
 export async function getCommuneBanIdByCodeCommune(
   codeCommune: string,
-): Promise<DistrictBanRsponse> {
+): Promise<DistrictBanResponse> {
   const response = await fetch(
     `${BAN_API_URL}/api/district/cog/${codeCommune}`,
   );
@@ -62,14 +62,14 @@ export async function computeRows(
     globalErrors: Set<string>;
   },
 ): Promise<ValidateRowType[]> {
-  const indexCommuneBanIds = await getCommuneBanIds(parsedRows);
+  const mapCodeCommuneBanIds = await getCommuneBanIds(parsedRows);
   const indexedFields: Record<string, FieldType> = keyBy(fields, 'name');
   const computedRows: ValidateRowType[] = await bluebird.map(
     parsedRows,
     async (parsedRow: Record<string, string>, line: number) => {
       const computedRow: ValidateRowType = validateRow(parsedRow, {
         indexedFields,
-        indexCommuneBanIds,
+        mapCodeCommuneBanIds,
         line,
       });
       for (const e of computedRow.errors) {
@@ -88,7 +88,7 @@ export async function computeRows(
         globalErrors.add(code);
       },
     },
-    { communeBanIds: Object.values(indexCommuneBanIds) },
+    { communeBanIds: Object.values(mapCodeCommuneBanIds) },
   );
 
   return computedRows;
@@ -137,11 +137,11 @@ export function validateRow(
   row: Record<string, string>,
   {
     indexedFields,
-    indexCommuneBanIds,
+    mapCodeCommuneBanIds,
     line,
   }: {
     indexedFields: Record<string, FieldType>;
-    indexCommuneBanIds: Record<string, string>;
+    mapCodeCommuneBanIds: Record<string, string>;
     line: number;
   },
 ): ValidateRowType {
@@ -211,7 +211,7 @@ export function validateRow(
       },
     },
     {
-      indexCommuneBanIds,
+      mapCodeCommuneBanIds,
     },
   );
 

--- a/lib/validate/validate.type.ts
+++ b/lib/validate/validate.type.ts
@@ -14,6 +14,7 @@ export type ErrorType = {
 export type ValidateRowType = {
   rawValues: Record<string, string>;
   parsedValues: ParsedValues;
+  remediations: ParsedValues;
   additionalValues: Record<string, any>;
   localizedValues: Record<string, any>;
   errors: ErrorType[];

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prepublishOnly": "yarn build-minicog && yarn build && yarn transpile"
   },
   "dependencies": {
+    "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.4.1",
     "@etalab/project-legal": "^0.6.0",
     "blob-to-buffer": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "fs-extra": "^10.1.0",
     "jest": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "nyc": "^15.1.0",
     "pkg": "^5.8.0",
     "prettier": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,17 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@ban-team/adresses-util@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/adresses-util/-/adresses-util-0.9.0.tgz#7b137c3507a1c543d0f91d60ceff478363a9d5ba"
+  integrity sha512-d64e1HRxuAcn5z7JDPHbavVg6nJrBoFBL0qSMUwIPX5Y1uAqT5AdFcCQ/TRGguR35BinVBMocQ0QAA3pFOCNGg==
+  dependencies:
+    "@turf/distance" "^6.3.0"
+    leven "^3.1.0"
+    lodash "^4.17.20"
+    talisman "^1.1.4"
+    written-number "^0.9.1"
+
 "@ban-team/shared-data@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.4.1.tgz#befd80777dd8a5f80262d65730f92c3a1c8a0116"
@@ -1782,6 +1793,26 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.0.0.tgz#9c13c2574c92d4503b005feca8f2e16cc1611506"
   integrity sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==
+
+"@turf/distance@^6.3.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.5.0.tgz#21f04d5f86e864d54e2abde16f35c15b4f36149a"
+  integrity sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/helpers@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
+  integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/invariant@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
+  integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -3285,6 +3316,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+html-entities@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
+  integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
+
 html-escaper@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
@@ -4111,10 +4147,15 @@ lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.21:
+lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4233,6 +4274,20 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+mnemonist@^0.38.1:
+  version "0.38.5"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.5.tgz#4adc7f4200491237fe0fa689ac0b86539685cade"
+  integrity sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==
+  dependencies:
+    obliterator "^2.0.0"
+
+mnemonist@^0.39.2:
+  version "0.39.8"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.39.8.tgz#9078cd8386081afd986cca34b52b5d84ea7a4d38"
+  integrity sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==
+  dependencies:
+    obliterator "^2.0.1"
 
 ms@2.1.2:
   version "2.1.2"
@@ -4358,6 +4413,16 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
+
+obliterator@^2.0.0, obliterator@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.5.tgz#031e0145354b0c18840336ae51d41e7d6d2c76aa"
+  integrity sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4438,6 +4503,13 @@ package-hash@^4.0.0:
     hasha "^5.0.0"
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
+
+pandemonium@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/pandemonium/-/pandemonium-2.4.1.tgz#bd51ca72184c6ae135f9049a33c8605bfdb9574d"
+  integrity sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==
+  dependencies:
+    mnemonist "^0.39.2"
 
 papaparse@^5.3.2:
   version "5.3.2"
@@ -5143,6 +5215,18 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
+talisman@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/talisman/-/talisman-1.1.4.tgz#649fdc3bc6e631c17405742edee338133fb8ac69"
+  integrity sha512-XZ/vf5B2aW5A0c0CE6F6w/UgdBdD/0ClBgh/phpYSjV1CnQIFni3bKZ1z9ZXWHkGZRSpnbiWWMPx05DoxXBoFw==
+  dependencies:
+    html-entities "^1.4.0"
+    lodash "^4.17.20"
+    long "^4.0.0"
+    mnemonist "^0.38.1"
+    obliterator "^1.6.1"
+    pandemonium "^2.0.0"
+
 tar-fs@^2.0.0, tar-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
@@ -5474,6 +5558,11 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+written-number@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/written-number/-/written-number-0.9.1.tgz#a400a4d2d6ca2575ad2afc62dc28d2d9f94f5e7e"
+  integrity sha512-tl2EquIdCYnEeGu3p71GRsEJSqnD15CXjVtR6Hl0AFO0PrQ+SATIe3Sf4phaaKwLIuGRzWmA4+sThjJCZqwK1A==
 
 y18n@^4.0.0:
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,6 +2545,13 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-fetch@^3.0.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
+  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
+  dependencies:
+    node-fetch "^2.7.0"
+
 cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -3724,6 +3731,14 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
@@ -4254,7 +4269,7 @@ node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
-node-fetch@^2.6.1, node-fetch@^2.6.6:
+node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -4615,6 +4630,11 @@ proj4@^2.8.0:
   dependencies:
     mgrs "1.0.0"
     wkt-parser "^1.3.1"
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
## CHANGMENT NOTABLE

### ERREUR
- Ajout de l'erreur `rows.cog_no_match_id_ban_commune` si `id_ban_commune` n'est pas la correspondance du code_insee

### REMEDIATION
- Ajout de la remediation aux ids ban: Ajoute `id_ban_commune`, `id_ban_toponyme` et `id_ban_adresse` si il n'existe pas et autocomplète si il y en a un qui manque

### AUTOFIX
- Ajout de la fonction autofix qui : 
  - Garde les champs BAL  seulement
  - Range les champs dans le bonne ordre
  - Remplace par les remediations si elles existent