### PR TITLE
hotfix: correct remediation identifiant BAN

### DIFF
--- a/lib/schema/__tests__/rows.spec.ts
+++ b/lib/schema/__tests__/rows.spec.ts
@@ -246,4 +246,70 @@ describe('VALIDATE ROWS', () => {
     });
     expect(errors).toContain('rows.cog_no_match_id_ban_commune');
   });
+
+  it('TEST remediation des id_ban manquants avec changement de commune deleguee', async () => {
+    const errors: string[] = [];
+    const rows: any[] = [
+      {
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          commune_insee: '91534',
+          commune_deleguee_insee: '91535',
+        },
+        remediations: {},
+      },
+      {
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          suffixe: 'A',
+          commune_insee: '91534',
+          commune_deleguee_insee: '91536',
+        },
+        remediations: {},
+      },
+      {
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          suffixe: 'A',
+          commune_insee: '91534',
+          commune_deleguee_insee: '91536',
+        },
+        remediations: {},
+      },
+    ];
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
+
+    // Vérification que les remediations contiennent les id_ban
+    expect(rows[0].remediations).toHaveProperty('id_ban_commune');
+    expect(rows[0].remediations).toHaveProperty('id_ban_toponyme');
+    expect(rows[0].remediations).toHaveProperty('id_ban_adresse');
+
+    expect(rows[1].remediations).toHaveProperty('id_ban_commune');
+    expect(rows[1].remediations).toHaveProperty('id_ban_toponyme');
+    expect(rows[1].remediations).toHaveProperty('id_ban_adresse');
+
+    expect(rows[2].remediations).toHaveProperty('id_ban_commune');
+    expect(rows[2].remediations).toHaveProperty('id_ban_toponyme');
+    expect(rows[2].remediations).toHaveProperty('id_ban_adresse');
+
+    // Check reconnaissance des commune_deleguee
+    expect(rows[0].remediations.id_ban_toponyme).not.toBe(
+      rows[1].remediations.id_ban_toponyme,
+    );
+    expect(rows[1].remediations.id_ban_toponyme).toBe(
+      rows[2].remediations.id_ban_toponyme,
+    );
+
+    expect(rows[0].remediations.id_ban_adresse).not.toBe(
+      rows[1].remediations.id_ban_adresse,
+    );
+    expect(rows[1].remediations.id_ban_adresse).toBe(
+      rows[2].remediations.id_ban_adresse,
+    );
+  });
 });

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -60,7 +60,7 @@ function getMapNameVoieBanId(
   return chain(parsedRows)
     .keyBy(({ parsedValues }) => normalize(parsedValues.voie_nom))
     .map((row) => [
-      normalize(row.parsedValues.voie_nom),
+      `${normalize(row.parsedValues.voie_nom)}${row.parsedValues.commune_deleguee_insee}`,
       row.parsedValues.id_ban_toponyme ||
         row.additionalValues?.uid_adresse?.idBanToponyme ||
         uuid(),
@@ -96,7 +96,9 @@ function remediationBanIds(
   }
   if (!idBanToponyme) {
     row.remediations.id_ban_toponyme =
-      mapNomVoieBanId[normalize(row.parsedValues.voie_nom)];
+      mapNomVoieBanId[
+        `${normalize(row.parsedValues.voie_nom)}${row.parsedValues.commune_deleguee_insee}`
+      ];
   }
   if (!idBanAdresse && row.parsedValues.numero !== 99_999) {
     row.remediations.id_ban_adresse = uuid();

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -26,6 +26,14 @@ export async function getCommuneBanIdByCodeCommune(
   return response.json();
 }
 
+export function getVoieIdentifier({ parsedValues }: ValidateRowType) {
+  return `${normalize(parsedValues.voie_nom)}#${parsedValues.commune_deleguee_insee}`;
+}
+
+export function getNumeroIdentifier({ parsedValues }: ValidateRowType) {
+  return `${parsedValues.numero}#${parsedValues.suffixe}#${parsedValues.commune_deleguee_insee}`;
+}
+
 export async function getMapCodeCommuneBanId(
   parsedRows: ValidateRowType[],
 ): Promise<Record<string, string>> {
@@ -58,12 +66,9 @@ function getMapNameVoieBanId(
   parsedRows: ValidateRowType[],
 ): Record<string, string> {
   return chain(parsedRows)
-    .keyBy(
-      ({ parsedValues }) =>
-        `${normalize(parsedValues.voie_nom)}#${parsedValues.commune_deleguee_insee}`,
-    )
+    .keyBy((row) => getVoieIdentifier(row))
     .map((row) => [
-      `${normalize(row.parsedValues.voie_nom)}#${row.parsedValues.commune_deleguee_insee}`,
+      getVoieIdentifier(row),
       row.parsedValues.id_ban_toponyme ||
         row.additionalValues?.uid_adresse?.idBanToponyme ||
         uuid(),
@@ -77,12 +82,9 @@ function getMapNumeroBanId(
 ): Record<string, string> {
   return chain(parsedRows)
     .filter(({ parsedValues }) => parsedValues.numero !== 99_999)
-    .keyBy(
-      ({ parsedValues }) =>
-        `${parsedValues.numero}#${parsedValues.suffixe}#${parsedValues.commune_deleguee_insee}`,
-    )
+    .keyBy((row) => getNumeroIdentifier(row))
     .map((row) => [
-      `${row.parsedValues.numero}#${row.parsedValues.suffixe}#${row.parsedValues.commune_deleguee_insee}`,
+      getNumeroIdentifier(row),
       row.parsedValues.id_ban_adresse ||
         row.additionalValues?.uid_adresse?.idBanAdresse ||
         uuid(),


### PR DESCRIPTION
## CHANGEMENT NOTABLE

### Remédiation

- Avoir des `id_ban_toponyme` différent pour deux rue identique qui n'ont pas la même `commune_deleguee_insee`
- Avoir des `id_ban_adresse` identique si des numéros ont plusieurs positions