### PR TITLE
fix: commune insee incoherence

### DIFF
--- a/lib/schema/__tests__/fields.spec.ts
+++ b/lib/schema/__tests__/fields.spec.ts
@@ -1,32 +1,103 @@
+import fields from '../fields';
 import { date_der_maj } from '../fields/date_der_maj.field';
 
 describe('VALIDATE FIELDS', () => {
+  describe('cle_interop', () => {
+    it('cle_interop commune insee inexistante', () => {
+      const addError: (error: string) => void = jest.fn();
+      const setAdditionnalValues: (add: any) => void = jest.fn();
+
+      fields['cle_interop'].parse('1207A_1111_00001', {
+        addError,
+        setAdditionnalValues,
+      });
+
+      expect(addError).toHaveBeenCalledWith('commune_invalide');
+    });
+
+    it('cle_interop commune insee ancienne', () => {
+      const addError: (error: string) => void = jest.fn();
+      const setAdditionnalValues: (add: any) => void = jest.fn();
+
+      fields['cle_interop'].parse('12076_1111_00001', {
+        addError,
+        setAdditionnalValues,
+      });
+
+      expect(addError).toHaveBeenCalledWith('commune_ancienne');
+    });
+
+    it('cle_interop commune good', () => {
+      const addError: (error: string) => void = jest.fn();
+      const setAdditionnalValues: (add: any) => void = jest.fn();
+
+      fields['cle_interop'].parse('91534_1111_00001', {
+        addError,
+        setAdditionnalValues,
+      });
+
+      expect(addError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commune_insee', () => {
+    it('commune_insee inexistante', () => {
+      const addError: (error: string) => void = jest.fn();
+
+      fields['commune_insee'].parse('1207A', {
+        addError,
+      });
+
+      expect(addError).toHaveBeenCalledWith('commune_invalide');
+    });
+
+    it('commune_insee ancienne', () => {
+      const addError: (error: string) => void = jest.fn();
+
+      fields['commune_insee'].parse('12076', {
+        addError,
+      });
+
+      expect(addError).toHaveBeenCalledWith('commune_ancienne');
+    });
+
+    it('commune_insee commune good', () => {
+      const addError: (error: string) => void = jest.fn();
+
+      fields['commune_insee'].parse('91534', {
+        addError,
+      });
+
+      expect(addError).not.toHaveBeenCalled();
+    });
+  });
+
   describe('date_der_maj', () => {
-    // it('devrait ajouter une remediation pour une date au format dd/mm/yyyy', () => {
-    //   const addError = jest.fn();
-    //   const setRemediation = jest.fn();
+    it('devrait ajouter une remediation pour une date au format dd/mm/yyyy', () => {
+      const addError = jest.fn();
+      const setRemediation = jest.fn();
 
-    //   date_der_maj.parse('25/12/2023', { addError, setRemediation });
+      date_der_maj.parse('25/12/2023', { addError, setRemediation });
 
-    //   expect(addError).toHaveBeenCalledWith('date_invalide');
-    //   expect(setRemediation).toHaveBeenCalledWith({
-    //     errors: ['date_der_maj.date_invalide'],
-    //     value: '2023-12-25',
-    //   });
-    // });
+      expect(addError).toHaveBeenCalledWith('date_invalide');
+      expect(setRemediation).toHaveBeenCalledWith({
+        errors: ['date_der_maj.date_invalide'],
+        value: '2023-12-25',
+      });
+    });
 
-    // it('devrait ajouter une remediation pour une date au format dd/mm/yyyy', () => {
-    //   const addError = jest.fn();
-    //   const setRemediation = jest.fn();
+    it('devrait ajouter une remediation pour une date au format dd/mm/yyyy', () => {
+      const addError = jest.fn();
+      const setRemediation = jest.fn();
 
-    //   date_der_maj.parse('16 juillet 2023', { addError, setRemediation });
+      date_der_maj.parse('16 juillet 2023', { addError, setRemediation });
 
-    //   expect(addError).toHaveBeenCalledWith('date_invalide');
-    //   expect(setRemediation).toHaveBeenCalledWith({
-    //     errors: ['date_der_maj.date_invalide'],
-    //     value: '2023-07-16',
-    //   });
-    // });
+      expect(addError).toHaveBeenCalledWith('date_invalide');
+      expect(setRemediation).toHaveBeenCalledWith({
+        errors: ['date_der_maj.date_invalide'],
+        value: '2023-07-16',
+      });
+    });
 
     it('devrait utiliser la date du jour comme remediation par défaut', () => {
       const addError = jest.fn();

--- a/lib/schema/__tests__/row.spec.ts
+++ b/lib/schema/__tests__/row.spec.ts
@@ -38,6 +38,7 @@ describe('VALIDATE ROW', () => {
       },
     });
   });
+
   it('TEST commune_nom avec commune_insee', async () => {
     const remediations: any = {};
     const row: any = {
@@ -89,6 +90,118 @@ describe('VALIDATE ROW', () => {
         errors: ['field.date_der_maj.missing'],
         value: format(new Date(), 'yyyy-MM-dd'),
       },
+    });
+  });
+
+  describe('code_insee chef lieu', () => {
+    it('TEST bad chef lieu', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_nom: 'Saclay',
+          commune_deleguee_insee: '12076',
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {},
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).toHaveBeenCalledWith('chef_lieu_invalide');
+    });
+    it('TEST no code_delegee_insee', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {},
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).not.toHaveBeenCalledWith('chef_lieu_invalide');
+    });
+
+    it('TEST code_delegee_insee not chef lieu', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_deleguee_insee: '12076',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {},
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).not.toHaveBeenCalledWith('chef_lieu_invalide');
+    });
+
+    it('TEST code_delegee_insee not chef lieu', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_deleguee_insee: '12076',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {},
+        remediations: {},
+        errors: [{ schemaName: 'commune_deleguee_insee' }],
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).not.toHaveBeenCalledWith('chef_lieu_invalide');
     });
   });
 });

--- a/lib/schema/error-labels.ts
+++ b/lib/schema/error-labels.ts
@@ -68,11 +68,7 @@ const errorLabels: Record<string, string> = {
 
   // commune_deleguee_insee
   'commune_deleguee_insee.commune_invalide':
-    'Le code INSEE renseigné n’est pas un code valide ou n’a jamais existé',
-  'commune_deleguee_insee.commune_actuelle_non_deleguee':
-    'Le code INSEE renseigné correspond au code d’une commune actuelle dont le chef lieu n’est pas une commune déléguée',
-  'commune_deleguee_insee.commune_ancienne_non_deleguee':
-    'Le code INSEE renseigné correspond au code d’une commune ancienne qui n’a pas le statut de commune déléguée',
+    'Le code INSEE de la commune déléguée renseigné n’est pas un code valide ou n’a jamais existé',
 
   // position
   'position.enum_fuzzy':

--- a/lib/schema/fields.ts
+++ b/lib/schema/fields.ts
@@ -11,15 +11,15 @@ export type FieldsSchema = {
   formats?: string[];
   allowRegionalLang?: boolean;
   parse?: (
-    value: any,
+    value: string,
     {
       addError,
       setAdditionnalValues,
       setRemediation,
     }: {
       addError: (error: string) => void;
-      setAdditionnalValues: (add: any) => void;
-      setRemediation: <T>(value: RemediationValue<T>) => void;
+      setAdditionnalValues?: (add: any) => void;
+      setRemediation?: <T>(value: RemediationValue<T>) => void;
     },
   ) => ParsedValue;
 };
@@ -55,7 +55,7 @@ const fields: Record<string, FieldsSchema> = {
     required: true,
     trim: true,
     formats: ['1.1', '1.2', '1.3', '1.4'],
-    parse(v, { addError, setAdditionnalValues }) {
+    parse(v: string, { addError, setAdditionnalValues }) {
       if (v.toLowerCase() !== v) {
         addError('casse_invalide');
       }
@@ -75,7 +75,7 @@ const fields: Record<string, FieldsSchema> = {
       const [, codeVoie, numeroVoie, ...suffixes] = splitted;
       const codeCommune = splitted[0].toUpperCase();
 
-      if (!isCommuneActuelle(codeCommune)) {
+      if (!isCommuneActuelle(codeCommune) && !isCommuneAncienne(codeCommune)) {
         addError('commune_invalide');
       } else if (isCommuneAncienne(codeCommune)) {
         addError('commune_ancienne');
@@ -116,7 +116,7 @@ const fields: Record<string, FieldsSchema> = {
   uid_adresse: {
     trim: true,
     formats: ['1.1', '1.2', '1.3'],
-    parse(v, { addError, setAdditionnalValues }) {
+    parse(v: string, { addError, setAdditionnalValues }) {
       const [uuidCommune] = v.match(/@c:(\S+)/gi) || [];
       const [uuidToponyme] = v.match(/@v:(\S+)/gi) || [];
       const [uuidAdresse] = v.match(/@a:(\S+)/gi) || [];
@@ -147,7 +147,7 @@ const fields: Record<string, FieldsSchema> = {
   id_ban_commune: {
     formats: ['1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (!isUuid(v)) {
         addError('type_invalide');
         return undefined;
@@ -160,7 +160,7 @@ const fields: Record<string, FieldsSchema> = {
   id_ban_toponyme: {
     formats: ['1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (!isUuid(v)) {
         addError('type_invalide');
         return undefined;
@@ -173,7 +173,7 @@ const fields: Record<string, FieldsSchema> = {
   id_ban_adresse: {
     formats: ['1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (!isUuid(v)) {
         addError('type_invalide');
         return undefined;
@@ -188,7 +188,7 @@ const fields: Record<string, FieldsSchema> = {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
     allowRegionalLang: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (v.length < 3) {
         addError('trop_court');
         return undefined;
@@ -227,7 +227,7 @@ const fields: Record<string, FieldsSchema> = {
     required: true,
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (!/^\d+$/.test(v)) {
         addError('type_invalide');
         return undefined;
@@ -251,7 +251,7 @@ const fields: Record<string, FieldsSchema> = {
   suffixe: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (!/^[\da-z]/i.test(v)) {
         addError('debut_invalide');
         return undefined;
@@ -270,10 +270,10 @@ const fields: Record<string, FieldsSchema> = {
     required: true,
     formats: ['1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       const code = v.toUpperCase();
 
-      if (!isCommuneActuelle(code)) {
+      if (!isCommuneActuelle(code) && !isCommuneAncienne(code)) {
         addError('commune_invalide');
         return;
       } else if (isCommuneAncienne(code)) {
@@ -294,13 +294,12 @@ const fields: Record<string, FieldsSchema> = {
   commune_deleguee_insee: {
     formats: ['1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       const code = v.toUpperCase();
 
-      if (!isCommuneAncienne(code)) {
-        addError('commune_non_deleguee');
+      if (!isCommuneActuelle(code) && !isCommuneAncienne(code)) {
+        addError('commune_invalide');
       }
-
       return code;
     },
   },
@@ -314,7 +313,7 @@ const fields: Record<string, FieldsSchema> = {
   position: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       const normalizedValue = getNormalizedEnumValue(v);
 
       if (enumPositionMap.has(normalizedValue)) {
@@ -332,7 +331,7 @@ const fields: Record<string, FieldsSchema> = {
   x: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (isValidFloat(v)) {
         return Number.parseFloat(v);
       }
@@ -349,7 +348,7 @@ const fields: Record<string, FieldsSchema> = {
   y: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (isValidFloat(v)) {
         return Number.parseFloat(v);
       }
@@ -366,7 +365,7 @@ const fields: Record<string, FieldsSchema> = {
   long: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (isValidFloat(v)) {
         return Number.parseFloat(v);
       }
@@ -383,7 +382,7 @@ const fields: Record<string, FieldsSchema> = {
   lat: {
     formats: ['1.1', '1.2', '1.3', '1.4'],
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (isValidFloat(v)) {
         return Number.parseFloat(v);
       }
@@ -401,7 +400,7 @@ const fields: Record<string, FieldsSchema> = {
     formats: ['1.2', '1.3', '1.4'],
     trim: true,
 
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       const pTrimmedValue = trim(v, '|');
 
       if (pTrimmedValue !== v) {
@@ -440,7 +439,7 @@ const fields: Record<string, FieldsSchema> = {
     formats: ['1.3', '1.4'],
     required: false,
     trim: true,
-    parse(v, { addError }) {
+    parse(v: string, { addError }) {
       if (v === '1') {
         return true;
       }

--- a/lib/schema/fields/date_der_maj.field.ts
+++ b/lib/schema/fields/date_der_maj.field.ts
@@ -27,7 +27,7 @@ function calculateRemediation(
     if (isValid(date) && date > new Date('2010-01-01') && date < new Date()) {
       setRemediation({
         errors: ['date_der_maj.date_invalide'],
-        value: format(new Date(), 'yyyy-MM-dd'),
+        value: format(date, 'yyyy-MM-dd'),
       });
       return;
     }


### PR DESCRIPTION
## CORRECTION

### CODE_COMMUNE

- Lorsque le `commune_insee` (et commune `cle_interop`) était une commune ancienne cela lançait l'erreur `commune_insee.commune_invalide` ou `cle_interop.commune_invalide`
FIX : Maintenant lance l'erreur `*.commune_ancienne`

- Lorsque le `commune_deleguee_insee` n'était pas une commune délégué cela lançait l'erreur `commune_deleguee_insee.commune_non_deleguee`
FIX: Maintenant vérifie seulement que `commune_deleguee_insee` existe et sinon lance l'erreur `commune_deleguee_insee.commune_invalide`

- Suppression des erreur `commune_deleguee_insee.commune_actuelle_non_deleguee` et `commune_deleguee_insee.commune_ancienne_non_deleguee`non exploité

- Lorsque le `commune_deleguee_insee` est le même que le `commune_insee` (cas rare de fusion) cela lançait l'erreur `row.chef_lieu_invalide`
FIX: Maintenant on ne lance pas l'erreur `row.chef_lieu_invalide` si le `commune_deleguee_insee` = `commune_insee` ou si il y a eu une erreur précédente sur l'un de c'est 2 champs

### DATE_DER_MAJ

- Lorsque l'on interprétait une date mal formaté (par ex 01/07/2011) cela donnait comme remédiation la date du jour au bon format
FIX: Maintenant la date remédiation est celle qui est interprété