### PR TITLE
fix: delete ancienne commune minicog

### DIFF
--- a/lib/utils/cog.ts
+++ b/lib/utils/cog.ts
@@ -1,27 +1,15 @@
-import { flatten } from 'lodash';
+import { flatten, keyBy } from 'lodash';
 import communes from '../../minicog.json';
 
 export type CommuneMiniCOG = {
   code: string;
   nom: string;
-  chefLieu?: string;
   anciensCodes?: string[];
 };
 
-const communesIndex: Record<string, CommuneMiniCOG> = communes.reduce(
-  (acc, commune) => {
-    if (!acc[commune.code] || commune.anciensCodes?.length > 0) {
-      acc[commune.code] = commune;
-    }
+const communesIndex: Record<string, CommuneMiniCOG> = keyBy(communes, 'code');
 
-    return acc;
-  },
-  {} as Record<string, CommuneMiniCOG>,
-);
-
-const codesCommunesActuelles = new Set(
-  communes.filter((c) => !c.chefLieu).map((c) => c.code),
-);
+const codesCommunesActuelles = new Set(Object.keys(communesIndex));
 
 const codesCommunesAnciennes = new Set(
   flatten(communes.map((c) => c.anciensCodes || [])),

--- a/scripts/build-minicog.js
+++ b/scripts/build-minicog.js
@@ -15,14 +15,10 @@ async function main() {
     )
     .map((c) => ({ code: c.code, nom: c.nom, anciensCodes: c.anciensCodes }));
 
-  const communesDelegueesAssociees = communes
-    .filter((c) => ['commune-associee', 'commune-deleguee'].includes(c.type))
-    .map((c) => ({ code: c.code, nom: c.nom, chefLieu: c.chefLieu }));
-
-  await outputJson(path.join(__dirname, '..', 'minicog.json'), [
-    ...communesActuelles,
-    ...communesDelegueesAssociees,
-  ]);
+  await outputJson(
+    path.join(__dirname, '..', 'minicog.json'),
+    communesActuelles,
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## CONTEXT

J'ai validé la PR https://github.com/BaseAdresseNationale/validateur-bal/pull/122 un peu vite, il fallait plutot directement enlever les communes anciennes du minicog.json. On ne les utilise pas, cela va alléger les executable