### PR TITLE
fix: bug longlat_vides no detected when numero zero

### DIFF
--- a/lib/schema/__tests__/row.spec.ts
+++ b/lib/schema/__tests__/row.spec.ts
@@ -204,4 +204,94 @@ describe('VALIDATE ROW', () => {
       expect(addError).not.toHaveBeenCalledWith('chef_lieu_invalide');
     });
   });
+
+  describe('validation des coordonnées', () => {
+    it('TEST alerte longlat_vides quand numero est "0" et pas de long/lat', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 0,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {
+          // Pas de longitude ni latitude
+        },
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).toHaveBeenCalledWith('longlat_vides');
+    });
+
+    it('TEST pas d\'alerte longlat_vides quand numero est "0" mais long/lat présents', async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 0,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {
+          long: 2.1699,
+          lat: 48.7069,
+        },
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).not.toHaveBeenCalledWith('longlat_vides');
+    });
+
+    it("TEST pas d'alerte longlat_vides quand numero est 99999 (toponyme)", async () => {
+      const row: any = {
+        parsedValues: {
+          commune_insee: '91534',
+          commune_nom: 'Saclay',
+          voie_nom: 'rue du Colombier',
+          numero: 99999,
+          date_der_maj: '2023-12-25',
+        },
+        rawValues: {
+          // Pas de longitude ni latitude
+        },
+        remediations: {},
+      };
+
+      const addError: (error: string) => void = jest.fn();
+      const addRemediation: <T>(
+        key: string,
+        value: RemediationValue<T>,
+      ) => void = jest.fn();
+
+      await validateRow(row, {
+        addError,
+        addRemediation,
+      });
+
+      expect(addError).not.toHaveBeenCalledWith('longlat_vides');
+    });
+  });
 });

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -87,7 +87,7 @@ function validateCoords(
 ) {
   // VERIFIE QU'IL Y AI LONG/LAT SI C'EST UN NUMERO (NON TOPONYME)
   if (
-    row.parsedValues.numero &&
+    'numero' in row.parsedValues &&
     row.parsedValues.numero !== 99_999 &&
     (!row.rawValues.long || !row.rawValues.lat)
   ) {


### PR DESCRIPTION
## CONTEXT

https://mattermost.incubateur.net/fab-geocommuns/pl/oersmh11sbdw7jzxqajr6ou65h

En effet on ne lance pas l'erreur longlat_vides si le numero de la ligne est 0
