### PR TITLE
feat: remediation toponyme_id with code fantoir

### DIFF
--- a/lib/schema/__tests__/rows.spec.ts
+++ b/lib/schema/__tests__/rows.spec.ts
@@ -395,4 +395,89 @@ describe('VALIDATE ROWS', () => {
       rows[3].remediations.id_ban_adresse.value,
     );
   });
+
+  it('TEST remediation des id_ban_toponyme avec codeVoie différents', async () => {
+    const errors: string[] = [];
+    const rows: any[] = [
+      {
+        additionalValues: {
+          cle_interop: {
+            codeVoie: 'ABCD',
+          },
+        },
+        parsedValues: {
+          id_ban_toponyme: '0246e48c-f33d-433a-8984-034219be842e',
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          commune_insee: '91534',
+        },
+        remediations: {},
+        rawValues: {},
+      },
+      {
+        additionalValues: {
+          cle_interop: {
+            codeVoie: 'EFGH',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 1,
+          commune_insee: '91534',
+        },
+        remediations: {},
+        rawValues: {},
+      },
+      {
+        additionalValues: {
+          cle_interop: {
+            codeVoie: 'ABCD',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 2,
+          commune_insee: '91534',
+        },
+        remediations: {},
+        rawValues: {},
+      },
+      {
+        additionalValues: {
+          cle_interop: {
+            codeVoie: 'EFGH',
+          },
+        },
+        parsedValues: {
+          voie_nom: 'rue du Colombier',
+          numero: 2,
+          commune_insee: '91534',
+        },
+        remediations: {},
+        rawValues: {},
+      },
+    ];
+
+    await validateRows(rows, {
+      addError: (e: string) => errors.push(e),
+    });
+    // Vérification que les remediations contiennent les id_ban_toponyme
+    expect(rows[1].remediations).toHaveProperty('id_ban_toponyme');
+    expect(rows[2].remediations).toHaveProperty('id_ban_toponyme');
+    expect(rows[3].remediations).toHaveProperty('id_ban_toponyme');
+
+    // Vérification que les voies avec le même nom mais codeVoie différents ont des id_ban_toponyme différents
+    expect(rows[0].parsedValues.id_ban_toponyme).toBe(
+      rows[2].remediations.id_ban_toponyme.value,
+    );
+    expect(rows[1].remediations.id_ban_toponyme.value).toBe(
+      rows[3].remediations.id_ban_toponyme.value,
+    );
+    expect(rows[0].parsedValues.id_ban_toponyme).not.toBe(
+      rows[1].remediations.id_ban_toponyme.value,
+    );
+    expect(rows[2].remediations.id_ban_toponyme.value).not.toBe(
+      rows[3].remediations.id_ban_toponyme.value,
+    );
+  });
 });

--- a/lib/schema/rows.ts
+++ b/lib/schema/rows.ts
@@ -25,8 +25,11 @@ export async function getCommuneBanIdByCodeCommune(
   return response.json();
 }
 
-export function getVoieIdentifier({ parsedValues }: ValidateRowType) {
-  return `${normalize(parsedValues.voie_nom)}#${parsedValues.commune_deleguee_insee}`;
+export function getVoieIdentifier({
+  parsedValues,
+  additionalValues,
+}: ValidateRowType) {
+  return `${normalize(parsedValues.voie_nom)}#${parsedValues.commune_deleguee_insee}#${additionalValues?.cle_interop?.codeVoie}`;
 }
 
 export function getNumeroIdentifier({ parsedValues }: ValidateRowType) {


### PR DESCRIPTION
## CONTEXT

Prendre en compte le code fantoir présent dans la cle_interop pour la remédiation des ban_toponyme_id
Car certaine commune remplisse bien la cle_interop avec des code fantoir pour signifier que ce sont des rue différentes