### PR TITLE
fix: return igngbbourcier

### DIFF
--- a/lib/schema/__tests__/row.spec.ts
+++ b/lib/schema/__tests__/row.spec.ts
@@ -263,6 +263,7 @@ describe('VALIDATE ROW', () => {
       });
 
       expect(addError).not.toHaveBeenCalledWith('longlat_vides');
+      expect(addError).toHaveBeenCalledWith('longlat_invalides');
     });
 
     it("TEST pas d'alerte longlat_vides quand numero est 99999 (toponyme)", async () => {

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -94,7 +94,7 @@ function validateCoords(
   if (
     'numero' in row.parsedValues &&
     row.parsedValues.numero !== 99_999 &&
-    (!long || !lat)
+    (!row.rawValues.long || !row.rawValues.lat)
   ) {
     addError('longlat_vides');
   } else {

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -85,21 +85,19 @@ function validateCoords(
   row: ValidateRowType,
   { addError }: { addError: (code: string) => void },
 ) {
-  // VERIFIE QU'IL Y AI LONG/LAT SI C'EST UN NUMERO (NON TOPONYME)
-  if (
-    'numero' in row.parsedValues &&
-    row.parsedValues.numero !== 99_999 &&
-    (!row.rawValues.long || !row.rawValues.lat)
-  ) {
-    addError('longlat_vides');
-  }
-
   const long: number = row.parsedValues.long as number;
   const lat: number = row.parsedValues.lat as number;
   const x: number = row.parsedValues.x as number;
   const y: number = row.parsedValues.y as number;
 
-  if (long !== undefined && lat !== undefined) {
+  // VERIFIE QU'IL Y AI LONG/LAT SI C'EST UN NUMERO (NON TOPONYME)
+  if (
+    'numero' in row.parsedValues &&
+    row.parsedValues.numero !== 99_999 &&
+    (!long || !lat)
+  ) {
+    addError('longlat_vides');
+  } else {
     const projectedCoordInMeters = harmlessProj([long, lat]);
     if (projectedCoordInMeters) {
       if (x !== undefined && y !== undefined) {

--- a/lib/schema/row.ts
+++ b/lib/schema/row.ts
@@ -65,7 +65,7 @@ function validatePositionType(
 ) {
   // VERIFIE QU'IL Y A UN TYPE POSITION SI C'EST BIEN UN NUMERO (NON UN TOPONYME)
   if (
-    row.parsedValues.numero &&
+    'numero' in row.parsedValues &&
     row.parsedValues.numero !== 99_999 &&
     !row.rawValues.position
   ) {


### PR DESCRIPTION
## CONTEXT

Retours de igngbbourcier

- les lat lon si sont que des caractères blancs, on a un warning et pas une erreur (en erreur pour vide ou invalide)
- la modif support du numero (0) devrait être présent sur la fonction du dessus également (vérification position type) ?